### PR TITLE
Bump target .NET framework to 4.7.1

### DIFF
--- a/XIVLauncher.PatchInstaller/App.config
+++ b/XIVLauncher.PatchInstaller/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.1" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.7.1"/>
     </startup>
 </configuration>

--- a/XIVLauncher.PatchInstaller/XIVLauncher.PatchInstaller.csproj
+++ b/XIVLauncher.PatchInstaller/XIVLauncher.PatchInstaller.csproj
@@ -8,10 +8,11 @@
     <OutputType>Exe</OutputType>
     <RootNamespace>XIVLauncher.PatchInstaller</RootNamespace>
     <AssemblyName>XIVLauncher.PatchInstaller</AssemblyName>
-    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.7.1</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
     <Deterministic>true</Deterministic>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/XIVLauncher.PatchInstaller/XIVLauncher.PatchInstaller.csproj
+++ b/XIVLauncher.PatchInstaller/XIVLauncher.PatchInstaller.csproj
@@ -54,9 +54,6 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.5.0\lib\net461\System.ValueTuple.dll</HintPath>
-    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/XIVLauncher.PatchInstaller/packages.config
+++ b/XIVLauncher.PatchInstaller/packages.config
@@ -6,5 +6,4 @@
   <package id="Serilog.Sinks.Debug" version="1.0.1" targetFramework="net461" />
   <package id="Serilog.Sinks.File" version="4.1.0" targetFramework="net461" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" requireReinstallation="true" />
 </packages>

--- a/XIVLauncher.PatchInstaller/packages.config
+++ b/XIVLauncher.PatchInstaller/packages.config
@@ -6,5 +6,5 @@
   <package id="Serilog.Sinks.Debug" version="1.0.1" targetFramework="net461" />
   <package id="Serilog.Sinks.File" version="4.1.0" targetFramework="net461" />
   <package id="System.Diagnostics.Debug" version="4.3.0" targetFramework="net461" />
-  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" />
+  <package id="System.ValueTuple" version="4.5.0" targetFramework="net461" requireReinstallation="true" />
 </packages>


### PR DESCRIPTION
Also updates Nhaama to include goaaats/Nhaama#11.

`LocBamlToLocalizable` was already targeting 4.7.2, but I didn't think it was necessary to downgrade just for consistency's sake.