### PR TITLE
Various changes

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Build DotNet4
         run: |
           cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
-           .\MSBuild.exe $Env:GITHUB_WORKSPACE\XIVLauncher.sln /t:Build /p:Configuration=Release /p:DefineConstants=XL_NOAUTOUPDATE
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\XIVLauncher.sln /t:Build /p:Configuration=ReleaseNoUpdate
       - name: Upload artifact
         uses: actions/upload-artifact@master
         with:

--- a/XIVLauncher.sln
+++ b/XIVLauncher.sln
@@ -10,37 +10,22 @@ EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
-		Debug|x64 = Debug|x64
-		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-		Release|x64 = Release|x64
-		Release|x86 = Release|x86
+		ReleaseNoUpdate|Any CPU = ReleaseNoUpdate|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.Debug|x64.Build.0 = Debug|Any CPU
-		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.Debug|x86.Build.0 = Debug|Any CPU
 		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.Release|Any CPU.Build.0 = Release|Any CPU
-		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.Release|x64.ActiveCfg = Release|Any CPU
-		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.Release|x64.Build.0 = Release|Any CPU
-		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.Release|x86.ActiveCfg = Release|Any CPU
-		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.Release|x86.Build.0 = Release|Any CPU
+		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.ReleaseNoUpdate|Any CPU.ActiveCfg = ReleaseNoUpdate|Any CPU
+		{BEB33308-6E15-41F7-ACC8-86BB786E2E56}.ReleaseNoUpdate|Any CPU.Build.0 = ReleaseNoUpdate|Any CPU
 		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.Debug|x64.ActiveCfg = Debug|Any CPU
-		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.Debug|x64.Build.0 = Debug|Any CPU
-		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.Debug|x86.ActiveCfg = Debug|Any CPU
-		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.Debug|x86.Build.0 = Debug|Any CPU
 		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.Release|Any CPU.Build.0 = Release|Any CPU
-		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.Release|x64.ActiveCfg = Release|Any CPU
-		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.Release|x64.Build.0 = Release|Any CPU
-		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.Release|x86.ActiveCfg = Release|Any CPU
-		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.Release|x86.Build.0 = Release|Any CPU
+		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.ReleaseNoUpdate|Any CPU.ActiveCfg = Release|Any CPU
+		{395CDFAB-48F8-4EC5-833D-05F5795A157D}.ReleaseNoUpdate|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/XIVLauncher/App.xaml.cs
+++ b/XIVLauncher/App.xaml.cs
@@ -29,6 +29,8 @@ namespace XIVLauncher
     /// </summary>
     public partial class App : Application
     {
+        public const string RepoUrl = "https://github.com/goatcorp/FFXIVQuickLauncher";
+
         public static ILauncherSettingsV3 Settings;
 
         private UpdateLoadingDialog _updateWindow;

--- a/XIVLauncher/App.xaml.cs
+++ b/XIVLauncher/App.xaml.cs
@@ -33,7 +33,9 @@ namespace XIVLauncher
 
         public static ILauncherSettingsV3 Settings;
 
+#if !XL_NOAUTOUPDATE
         private UpdateLoadingDialog _updateWindow;
+#endif
 
         private readonly string[] _allowedLang = {"de", "ja", "fr", "it", "es"};
 
@@ -153,8 +155,10 @@ namespace XIVLauncher
             {
                 _useFullExceptionHandler = true;
 
+#if !XL_NOAUTOUPDATE
                 if (_updateWindow != null) 
                     _updateWindow.Hide();
+#endif
 
                 _mainWindow = new MainWindow();
                 _mainWindow.Initialize();

--- a/XIVLauncher/Updates.cs
+++ b/XIVLauncher/Updates.cs
@@ -11,7 +11,9 @@ namespace XIVLauncher
 { 
     class Updates
     {
+#if !XL_NOAUTOUPDATE
         public EventHandler OnUpdateCheckFinished;
+#endif
 
         public async Task Run(bool downloadPrerelease = false)
         {
@@ -29,8 +31,11 @@ namespace XIVLauncher
 
                 if (downloadedRelease != null)
                     UpdateManager.RestartApp();
+#if !XL_NOAUTOUPDATE
                 else
                     OnUpdateCheckFinished?.Invoke(this, null);
+#endif
+
             }
 
             // Reset security protocol after updating

--- a/XIVLauncher/Updates.cs
+++ b/XIVLauncher/Updates.cs
@@ -11,8 +11,6 @@ namespace XIVLauncher
 { 
     class Updates
     {
-        private const string RepoUrl = "https://github.com/goatcorp/FFXIVQuickLauncher";
-
         public EventHandler OnUpdateCheckFinished;
 
         public async Task Run(bool downloadPrerelease = false)
@@ -20,7 +18,7 @@ namespace XIVLauncher
             // GitHub requires TLS 1.2, we need to hardcode this for Windows 7
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
 
-            using (var updateManager = await UpdateManager.GitHubUpdateManager(repoUrl:RepoUrl, applicationName: "XIVLauncher", prerelease: downloadPrerelease))
+            using (var updateManager = await UpdateManager.GitHubUpdateManager(repoUrl: App.RepoUrl, applicationName: "XIVLauncher", prerelease: downloadPrerelease))
             {
                 SquirrelAwareApp.HandleEvents(
                     onInitialInstall: v => updateManager.CreateShortcutForThisExe(),

--- a/XIVLauncher/Util.cs
+++ b/XIVLauncher/Util.cs
@@ -10,6 +10,7 @@ using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Windows;
 using System.Windows.Media;
+using IWshRuntimeLibrary;
 using Microsoft.Win32;
 using XIVLauncher.Game;
 
@@ -50,14 +51,15 @@ namespace XIVLauncher
             return Directory.Exists(Path.Combine(path, "game")) && Directory.Exists(Path.Combine(path, "boot"));
         }
 
-        private static readonly string[] PathsToTry =
+        private static string DefaultPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "SquareEnix\\FINAL FANTASY XIV - A Realm Reborn");
+
+        private static readonly string[] PathsToTry = DriveInfo.GetDrives().Select(drive => $"{drive.Name}SquareEnix\\FINAL FANTASY XIV - A Realm Reborn").Concat(new List<string>
         {
-            "C:\\SquareEnix\\FINAL FANTASY XIV - A Realm Reborn",
-            "C:\\Program Files (x86)\\Steam\\steamapps\\common\\FINAL FANTASY XIV Online",
-            "C:\\Program Files (x86)\\Steam\\steamapps\\common\\FINAL FANTASY XIV - A Realm Reborn",
-            "C:\\Program Files (x86)\\FINAL FANTASY XIV - A Realm Reborn",
-            "C:\\Program Files (x86)\\SquareEnix\\FINAL FANTASY XIV - A Realm Reborn"
-        };
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam\\steamapps\\common\\FINAL FANTASY XIV Online"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam\\steamapps\\common\\FINAL FANTASY XIV - A Realm Reborn"),
+            Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "FINAL FANTASY XIV - A Realm Reborn"),
+            DefaultPath
+        }).ToArray();
 
         public static string TryGamePaths()
         {
@@ -65,7 +67,7 @@ namespace XIVLauncher
                 if (Directory.Exists(path) && IsValidFfxivPath(path))
                     return path;
 
-            return "C:\\Program Files (x86)\\SquareEnix\\FINAL FANTASY XIV - A Realm Reborn";
+            return DefaultPath;
         }
 
         public static int GetUnixMillis()

--- a/XIVLauncher/Util.cs
+++ b/XIVLauncher/Util.cs
@@ -10,7 +10,6 @@ using System.Runtime.InteropServices;
 using System.Security.Principal;
 using System.Windows;
 using System.Windows.Media;
-using IWshRuntimeLibrary;
 using Microsoft.Win32;
 using XIVLauncher.Game;
 

--- a/XIVLauncher/Windows/ChatChannelSetupWindow.xaml.cs
+++ b/XIVLauncher/Windows/ChatChannelSetupWindow.xaml.cs
@@ -141,7 +141,7 @@ namespace XIVLauncher.Windows
             if (e.ChangedButton != MouseButton.Left)
                 return;
 
-            Process.Start("https://github.com/goaaats/FFXIVQuickLauncher/wiki/How-to-get-discord-ids");
+            Process.Start($"{App.RepoUrl}/wiki/How-to-get-discord-ids");
         }
 
         private void ChatTypeComboBox_OnSelectionChanged(object sender, SelectionChangedEventArgs e)

--- a/XIVLauncher/Windows/ErrorWindow.xaml.cs
+++ b/XIVLauncher/Windows/ErrorWindow.xaml.cs
@@ -62,12 +62,12 @@ namespace XIVLauncher.Windows
 
         private void GitHubButton_OnClick(object sender, RoutedEventArgs e)
         {
-            Process.Start("https://github.com/goaaats/FFXIVQuickLauncher/issues/new");
+            Process.Start($"{App.RepoUrl}/issues/new");
         }
 
         private void FaqButton_OnClick(object sender, RoutedEventArgs e)
         {
-            Process.Start("https://github.com/goaaats/FFXIVQuickLauncher/wiki/FAQ");
+            Process.Start($"{App.RepoUrl}/wiki/FAQ");
         }
     }
 }

--- a/XIVLauncher/Windows/FirstTimeSetupWindow.xaml.cs
+++ b/XIVLauncher/Windows/FirstTimeSetupWindow.xaml.cs
@@ -27,7 +27,7 @@ namespace XIVLauncher.Windows
 
 #if XL_NOAUTOUPDATE
             MessageBox.Show(
-                "You're running an unsupported version of XIVLauncher.\n\nThis can be unsafe and a danger to your SE account. If you have not gotten this unsupported version on purpose, please reinstall a clean version from https://github.com/goaaats/FFXIVQuickLauncher/releases.",
+                $"You're running an unsupported version of XIVLauncher.\n\nThis can be unsafe and a danger to your SE account. If you have not gotten this unsupported version on purpose, please reinstall a clean version from {App.RepoUrl}/releases.",
                 "XIVLauncher Problem", MessageBoxButton.OK, MessageBoxImage.Exclamation);
 #endif
         }

--- a/XIVLauncher/Windows/MainWindow.xaml.cs
+++ b/XIVLauncher/Windows/MainWindow.xaml.cs
@@ -670,7 +670,7 @@ namespace XIVLauncher.Windows
 
         private void WorldStatusButton_Click(object sender, RoutedEventArgs e)
         {
-            Process.Start("http://is.xivup.com/");
+            Process.Start("https://is.xivup.com/");
         }
 
         private void QueueButton_OnClick(object sender, RoutedEventArgs e)

--- a/XIVLauncher/Windows/OtpInputDialog.xaml.cs
+++ b/XIVLauncher/Windows/OtpInputDialog.xaml.cs
@@ -84,7 +84,7 @@ namespace XIVLauncher.Windows
 
         public void OpenShortcutInfo_MouseUp(object sender, RoutedEventArgs e)
         {
-            Process.Start("https://github.com/goaaats/FFXIVQuickLauncher/wiki/Setting-up-OTP-Phone-Shortcuts");
+            Process.Start($"{App.RepoUrl}/wiki/Setting-up-OTP-Phone-Shortcuts");
         }
     }
 }

--- a/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -222,7 +222,7 @@ namespace XIVLauncher.Windows
             if (e.ChangedButton != MouseButton.Left)
                 return;
 
-            Process.Start("https://github.com/goaaats/FFXIVQuickLauncher/wiki/How-to-set-up-a-discord-bot");
+            Process.Start($"{App.RepoUrl}/wiki/How-to-set-up-a-discord-bot");
         }
 
         private void RemoveChatConfigEntry_OnClick(object sender, RoutedEventArgs e)

--- a/XIVLauncher/XIVLauncher.csproj
+++ b/XIVLauncher/XIVLauncher.csproj
@@ -56,6 +56,16 @@
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'ReleaseNoUpdate|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>..\bin\</OutputPath>
+    <DefineConstants>TRACE;XL_NOAUTOUPDATE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
+  </PropertyGroup>
   <PropertyGroup>
     <ApplicationIcon>Resources\dalamud_icon.ico</ApplicationIcon>
   </PropertyGroup>


### PR DESCRIPTION
* Create a separate build configuration that sets XL_NOAUTOUPDATE (I hope I don't break CI somehow)
* Remove x86 / x64 platforms since it's always built as Any CPU
CI log:
```
2020-07-21T17:55:41.5300245Z Project "D:\a\FFXIVQuickLauncher\FFXIVQuickLauncher\XIVLauncher.sln" on node 1 (Build target(s)).
2020-07-21T17:55:41.5323557Z ValidateSolutionConfiguration:
2020-07-21T17:55:41.5323921Z   Building solution configuration "Release|Any CPU".
```
* Move repo URL to a separate const string since the old URL (``https://github.com/goaaats/FFXIVQuickLauncher/``) was still being used in some places
* Modify the default game path checks to check every drive for the game folder (example: ``D:\SquareEnix\FINAL FANTASY XIV - A Realm Reborn``), and also use ``Environment.SpecialFolder.ProgramFilesX86`` instead of hardcoding "Program Files (x86)", since that directory doesn't exist on non-english 32-bit OSes afaik