### PR TITLE
Support for Windows Installations not on C:

### DIFF
--- a/XIVLauncher/Dalamud/DalamudLauncher.cs
+++ b/XIVLauncher/Dalamud/DalamudLauncher.cs
@@ -213,7 +213,7 @@ namespace XIVLauncher.Dalamud
 
         private static bool CheckVcRedist()
         {
-            if (File.Exists("C:\\Windows\\System32\\vcruntime140_clr0400.dll"))
+            if (File.Exists(Environment.ExpandEnvironmentVariables("%SystemRoot%\\System32\\vcruntime140_clr0400.dll")))
                 return true;
 
             var res = MessageBox.Show(


### PR DESCRIPTION
Change hardcoded C:\Windows value for %SystemRoot% to allow CheckVcRedist to work on people with Windows installations that are not on the C: drive or have their Windows folder named something else for some esoteric reason. WINE defines this environment variable so Linux shouldn't care.