### PR TITLE
Massively improve discord chat bridge

### DIFF
--- a/XIVLauncher/Dalamud/DiscordFeatureConfiguration.cs
+++ b/XIVLauncher/Dalamud/DiscordFeatureConfiguration.cs
@@ -17,6 +17,7 @@ namespace Dalamud.Discord
 
         public ulong GuildId { get; set; }
         public ulong ChannelId { get; set; }
+        public string ChannelPrefix { get; set; }
     }
 
     [Serializable]
@@ -35,6 +36,9 @@ namespace Dalamud.Discord
 
         public bool CheckForDuplicateMessages { get; set; }
         public int ChatDelayMs { get; set; }
+        public string AtlEmoji { get; set; }
+        public string AtrEmoji { get; set; }
+        public string HqEmoji { get; set; }
 
         public bool DisableEmbeds { get; set; }
 

--- a/XIVLauncher/Windows/ChatChannelSetupWindow.xaml
+++ b/XIVLauncher/Windows/ChatChannelSetupWindow.xaml
@@ -6,7 +6,7 @@
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
         xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
         mc:Ignorable="d"
-        Title="{Binding ChatChannelSetupTitleLoc}" Height="268.361" Width="535.302" WindowStartupLocation="CenterScreen"
+        Title="{Binding ChatChannelSetupTitleLoc}" Height="350" Width="535.302" WindowStartupLocation="CenterScreen"
         Icon="pack://application:,,,/Resources/dalamud_icon.ico" ResizeMode="NoResize"
         TextElement.Foreground="{DynamicResource MaterialDesignBody}"
         Background="{DynamicResource MaterialDesignPaper}"
@@ -28,11 +28,15 @@
             <StackPanel x:Uid="StackPanel_4" Orientation="Vertical" Width="180" HorizontalAlignment="Left">
                 <Label x:Uid="Label_2" Width="210" VerticalAlignment="Center" HorizontalAlignment="Left" Content="Server ID"/>
                 <TextBox x:Uid="ServerIdTextBox" x:Name="ServerIdTextBox" Width="203"/>
+                <Label x:Uid="Label_3" Width="210" VerticalAlignment="Center" HorizontalAlignment="Left" Content="(Optional) Channel Prefix"/>
+                <TextBox x:Uid="ChannelPrefixTextBox" x:Name="ChannelPrefixTextBox" Width="203"/>
             </StackPanel>
 
             <StackPanel x:Uid="StackPanel_5" Orientation="Vertical" Width="180" HorizontalAlignment="Right" Margin="60,0,0,0">
                 <Label x:Uid="Label_3" Width="210" VerticalAlignment="Center" HorizontalAlignment="Left">Channel ID</Label>
                 <TextBox x:Uid="ChannelIdTextBox" x:Name="ChannelIdTextBox" Width="203" VerticalAlignment="Center" HorizontalAlignment="Left"/>
+                <Label x:Uid="Label_4" Width="210" VerticalAlignment="Center" HorizontalAlignment="Left">Type \:emoji: and paste code</Label>
+                <Label x:Uid="Label_5" Width="210" VerticalAlignment="Center" HorizontalAlignment="Left">to use an emoji</Label>
             </StackPanel>
         </StackPanel>
 

--- a/XIVLauncher/Windows/ChatChannelSetupWindow.xaml.cs
+++ b/XIVLauncher/Windows/ChatChannelSetupWindow.xaml.cs
@@ -52,6 +52,7 @@ namespace XIVLauncher.Windows
             ChannelTypeComboBox.SelectedIndex = (int) channelConfig.Type;
             ChannelIdTextBox.Text = channelConfig.ChannelId.ToString();
             ServerIdTextBox.Text = channelConfig.GuildId.ToString();
+            ChannelPrefixTextBox.Text = channelConfig.ChannelPrefix.ToString();
         }
 
         public ChatChannelSetup(ChatTypeConfiguration chatTypeConfig = null)
@@ -85,6 +86,7 @@ namespace XIVLauncher.Windows
                 ChannelTypeComboBox.SelectedIndex = (int) chatTypeConfig.Channel.Type;
                 ChannelIdTextBox.Text = chatTypeConfig.Channel.ChannelId.ToString();
                 ServerIdTextBox.Text = chatTypeConfig.Channel.GuildId.ToString();
+                ChannelPrefixTextBox.Text = chatTypeConfig.Channel.ChannelPrefix?.ToString() ?? "";
 
                 ApplyColor(chatTypeConfig.Color);
             }
@@ -112,12 +114,15 @@ namespace XIVLauncher.Windows
                     }
                 }
 
+                var channelPrefix = ChannelPrefixTextBox.Text;
+
                 Result = new ChatTypeConfiguration
                 {
                     Channel = new ChannelConfiguration
                     {
                         ChannelId = channelId,
                         GuildId = guildId,
+                        ChannelPrefix = channelPrefix,
                         Type = (ChannelType) ChannelTypeComboBox.SelectedIndex
                     },
                     Color = _color

--- a/XIVLauncher/Windows/ChatChannelSetupWindow.xaml.cs
+++ b/XIVLauncher/Windows/ChatChannelSetupWindow.xaml.cs
@@ -52,7 +52,7 @@ namespace XIVLauncher.Windows
             ChannelTypeComboBox.SelectedIndex = (int) channelConfig.Type;
             ChannelIdTextBox.Text = channelConfig.ChannelId.ToString();
             ServerIdTextBox.Text = channelConfig.GuildId.ToString();
-            ChannelPrefixTextBox.Text = channelConfig.ChannelPrefix.ToString();
+            ChannelPrefixTextBox.Text = channelConfig.ChannelPrefix?.ToString() ?? "";
         }
 
         public ChatChannelSetup(ChatTypeConfiguration chatTypeConfig = null)

--- a/XIVLauncher/Windows/SettingsControl.xaml
+++ b/XIVLauncher/Windows/SettingsControl.xaml
@@ -220,6 +220,33 @@
                                          Foreground="{DynamicResource MaterialDesignBody}"
                                          materialDesign:HintAssist.Hint="{Binding InGameAddonChatDelayLoc}" />
 
+                                <Label Foreground="{DynamicResource MaterialDesignBody}" Margin="0,5,0,0"
+                                       Content="{Binding InGameAddonDiscordEmojiNoteLoc}" />
+
+                                <Label Foreground="{DynamicResource MaterialDesignBody}" Margin="0,5,0,0"
+                                       Content="{Binding InGameAddonAtransLeftLoc}" />
+                                <TextBox x:Uid="AtransLeftTextBox" x:Name="AtransLeftTextBox" Margin="10,0,0,5"
+                                         Width="400"
+                                         VerticalAlignment="Center" HorizontalAlignment="Left"
+                                         Foreground="{DynamicResource MaterialDesignBody}"
+                                         materialDesign:HintAssist.Hint="{Binding InGameAddonAtransLeftHintLoc}" />
+
+                                <Label Foreground="{DynamicResource MaterialDesignBody}" Margin="0,5,0,0"
+                                       Content="{Binding InGameAddonAtransRightLoc}" />
+                                <TextBox x:Uid="AtransRightTextBox" x:Name="AtransRightTextBox" Margin="10,0,0,5"
+                                         Width="400"
+                                         VerticalAlignment="Center" HorizontalAlignment="Left"
+                                         Foreground="{DynamicResource MaterialDesignBody}"
+                                         materialDesign:HintAssist.Hint="{Binding InGameAddonAtransRightHintLoc}" />
+
+                                <Label Foreground="{DynamicResource MaterialDesignBody}" Margin="0,5,0,0"
+                                       Content="{Binding InGameAddonHqLoc}" />
+                                <TextBox x:Uid="HqTextBox" x:Name="HqTextBox" Margin="10,0,0,5"
+                                         Width="400"
+                                         VerticalAlignment="Center" HorizontalAlignment="Left"
+                                         Foreground="{DynamicResource MaterialDesignBody}"
+                                         materialDesign:HintAssist.Hint="{Binding InGameAddonHqHintLoc}" />
+
                                 <Separator />
                                 
                                 <Separator x:Uid="Separator_2" />

--- a/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -74,6 +74,9 @@ namespace XIVLauncher.Windows
             DiscordBotTokenTextBox.Text = featureConfig.Token;
             CheckForDuplicateMessagesCheckBox.IsChecked = featureConfig.CheckForDuplicateMessages;
             ChatDelayTextBox.Text = featureConfig.ChatDelayMs.ToString();
+            AtransLeftTextBox.Text = featureConfig.AtlEmoji?.ToString() ?? "";
+            AtransRightTextBox.Text = featureConfig.AtrEmoji?.ToString() ?? "";
+            HqTextBox.Text = featureConfig.HqEmoji?.ToString() ?? "";
             DisableEmbedsCheckBox.IsChecked = featureConfig.DisableEmbeds;
 
             EnableHooksCheckBox.IsChecked = App.Settings.InGameAddonEnabled;
@@ -111,6 +114,9 @@ namespace XIVLauncher.Windows
             featureConfig.CheckForDuplicateMessages = CheckForDuplicateMessagesCheckBox.IsChecked == true;
             if (int.TryParse(ChatDelayTextBox.Text, out var parsedDelay))
                 featureConfig.ChatDelayMs = parsedDelay;
+            featureConfig.AtlEmoji = AtransLeftTextBox.Text ?? "";
+            featureConfig.AtrEmoji = AtransRightTextBox.Text ?? "";
+            featureConfig.HqEmoji = HqTextBox.Text ?? "";
             featureConfig.DisableEmbeds = DisableEmbedsCheckBox.IsChecked == true;
             DalamudSettings.DiscordFeatureConfig = featureConfig;
 

--- a/XIVLauncher/Windows/ViewModel/SettingsControlViewModel.cs
+++ b/XIVLauncher/Windows/ViewModel/SettingsControlViewModel.cs
@@ -102,6 +102,13 @@ namespace XIVLauncher.Windows.ViewModel
             InGameAddonChatDelayLoc = Loc.Localize("InGameAddonChatDelay", "Chat Post Delay");
             InGameAddonChatDelayDescriptionLoc = Loc.Localize("InGameAddonChatDelayDescription",
                 "Check for recently sent messages to avoid duplicates.\r\nThis allows for multiple users to use the same channel as a chat log.\r\nPlease set an appropriate delay in milliseconds below(e.g. 1000).");
+            InGameAddonDiscordEmojiNoteLoc = Loc.Localize("InGameAddonDiscordEmojiNote", "Note on Discord emojis: you may use any emote from any server the bot is in. Use \\:emote: in Discord to get the code to paste here.");
+            InGameAddonAtransLeftLoc = Loc.Localize("InGameAddonAtransLeft", "Use a Discord emoji for autotranslate left bracket");
+            InGameAddonAtransRightLoc = Loc.Localize("InGameAddonAtransRight", "Use a Discord emoji for autotranslate right bracket");
+            InGameAddonHqLoc = Loc.Localize("InGameAddonHq", "Use a Discord emoji for high quality symbol");
+            InGameAddonAtransLeftHintLoc = Loc.Localize("InGameAddonAtransLeftHint", "<:atL:12345>");
+            InGameAddonAtransRightHintLoc = Loc.Localize("InGameAddonAtransRightHint", "<:atR:12345>");
+            InGameAddonHqHintLoc = Loc.Localize("InGameAddonHqHint", "<:hq:12345>");
             UniversalisHintLoc = Loc.Localize("UniversalisHint",
                 "Market board data provided in cooperation with Universalis.");
             UniversalisOptOutLoc = Loc.Localize("UniversalisOptOut",
@@ -159,6 +166,13 @@ namespace XIVLauncher.Windows.ViewModel
         public string InGameAddonSetRetainerChannelLoc { get; private set; }
         public string InGameAddonChatDelayLoc { get; private set; }
         public string InGameAddonChatDelayDescriptionLoc { get; private set; }
+        public string InGameAddonDiscordEmojiNoteLoc { get; private set; }
+        public string InGameAddonAtransLeftLoc { get; private set; }
+        public string InGameAddonAtransRightLoc { get; private set; }
+        public string InGameAddonHqLoc { get; private set; }
+        public string InGameAddonAtransLeftHintLoc { get; private set; }
+        public string InGameAddonAtransRightHintLoc { get; private set; }
+        public string InGameAddonHqHintLoc { get; private set; }
         public string UniversalisHintLoc { get; private set; }
         public string UniversalisOptOutLoc { get; private set; }
 


### PR DESCRIPTION
I have fixed up the Discord chat bridge functionality quite a bit to be MUCH nicer! This pull request also requires #https://github.com/goatcorp/Dalamud/pull/144 to function properly.

Note that while many if not most of these improvements work in the embed mode, turning it off is a much nicer experience and will enable the "Chat Prefix" functionality. I recommend changing the default to disabling embeds, but I will leave this consideration to the upstream developers.

Here is a summary of what this and its companion patch on XIVLauncher does.

- Chat formatting overall has been updated to more closely resemble the game
- - Bolding is only for chatmode tag
- - Chatmode tag is in all caps, just like in the game
- - cw1, cw2 etc have been changed to cwls1, cwls2 etc to match the in game chat
- - Free Company messages no longer include world next to the character name
- - World identifier changed from " at " to "@" for easier copy and paste
- Option on each chatmode to prepend a string for the non-embedded version, intended mainly for using Discord emoji representing things such as a linkshell or free company crest to differentiate different chats
- Every single character in the XIV special characters codepage has been given a unicode equivalent, or at least, as close as possible. No more ugly boxes any time someone links an item or uses autotranslate! 
- As the autotranslate arrows and hq icons are simultaneously iconic and options to represent them in unicode is poor, there are now additional settings in the "In-Game" configuration to use a Discord emoji of your choosing for these three icons

