### PR TITLE
Add registry-based redist checks

### DIFF
--- a/XIVLauncher/Dalamud/DalamudLauncher.cs
+++ b/XIVLauncher/Dalamud/DalamudLauncher.cs
@@ -222,7 +222,7 @@ namespace XIVLauncher.Dalamud
             else if (!CheckDotNet48() && CheckVc2019())
             {
                 var res = MessageBox.Show(
-                Loc.Localize("DalamudVcRedistError",
+                Loc.Localize("DalamudDotNet48RedistError",
                     "The XIVLauncher in-game addon needs the .NET Framework 4.8 to be installed to continue. Please install it from the Microsoft homepage."),
                 "XIVLauncher", MessageBoxButton.OK, MessageBoxImage.Exclamation);
 
@@ -231,7 +231,7 @@ namespace XIVLauncher.Dalamud
             else if (CheckDotNet48() && !CheckVc2019())
             {
                 var res = MessageBox.Show(
-                Loc.Localize("DalamudVcRedistError",
+                Loc.Localize("DalamudVc2019RedistError",
                     "The XIVLauncher in-game addon needs the Microsoft Visual C++ 2015-2019 redistributable to be installed to continue. Please install it from the Microsoft homepage."),
                 "XIVLauncher", MessageBoxButton.OK, MessageBoxImage.Exclamation);
 


### PR DESCRIPTION
Added in registry-based .Net 4.8 and VC 2015-2019 checks. Kept the dll check in too, just in case something has gone horrifically wrong.