### PR TITLE
Fixing the maintenance button + a bit of refactoring

### DIFF
--- a/XIVLauncher/Windows/MainWindow.xaml.cs
+++ b/XIVLauncher/Windows/MainWindow.xaml.cs
@@ -670,9 +670,15 @@ namespace XIVLauncher.Windows
 
         private void QueueButton_OnClick(object sender, RoutedEventArgs e)
         {
-            if (_maintenanceQueueTimer != null)
-                return;
+            if (_maintenanceQueueTimer == null)
+                SetupMaintenanceQueueTimer();
 
+            DialogHost.OpenDialogCommand.Execute(null, MaintenanceQueueDialogHost);
+            _maintenanceQueueTimer.Start();
+        }
+
+        private void SetupMaintenanceQueueTimer()
+        {
             _maintenanceQueueTimer = new Timer
             {
                 Interval = 15000
@@ -720,9 +726,6 @@ namespace XIVLauncher.Windows
                     }));
                 }
             };
-
-            DialogHost.OpenDialogCommand.Execute(null, MaintenanceQueueDialogHost);
-            _maintenanceQueueTimer.Start();
         }
 
         private void QuitMaintenanceQueueButton_OnClick(object sender, RoutedEventArgs e)


### PR DESCRIPTION
Allows the maintenance button to be reused. Currently, if you cancel it, you cannot use it again because it returns before starting it. I have moved the setup of the timer to another method, this is not needed, but I figured that it would be clearer (maybe not?).