### PR TITLE
fix: accommodating other languages by tweaking UI

### DIFF
--- a/XIVLauncher/Properties/Settings.Designer.cs
+++ b/XIVLauncher/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace XIVLauncher.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.5.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "16.4.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/XIVLauncher/Windows/MainWindow.xaml
+++ b/XIVLauncher/Windows/MainWindow.xaml
@@ -11,7 +11,7 @@
     xmlns:windows="clr-namespace:XIVLauncher.Windows"
     mc:Ignorable="d"
     Title="XIVLauncher"
-    Width="845"
+    Width="875"
     Height="376"
     ResizeMode="CanMinimize" WindowStartupLocation="CenterScreen"
     Icon="pack://application:,,,/Resources/dalamud_icon.ico"
@@ -169,13 +169,13 @@
                             <materialDesign:Card
                                 Grid.Row="0"
                                 Grid.Column="1"
-                                Width="255"
+                                Width="295"
                                 Margin="0"
                                 HorizontalAlignment="Right"
                                 VerticalAlignment="Stretch"
                                 KeyDown="Card_KeyDown">
                                 <DockPanel
-                                    Margin="30,18,30,18">
+                                    Margin="25,18">
                                     <TextBox
                                         DockPanel.Dock="Top"
                                         x:Name="LoginUsername"
@@ -217,11 +217,11 @@
                                     <StackPanel Orientation="Horizontal"
                                                 HorizontalAlignment="Center"
                                                 VerticalAlignment="Bottom"
-                                                Width="142" Margin="0,0,0,0" DockPanel.Dock="Bottom">
+                                                Width="176" DockPanel.Dock="Bottom" Margin="29,0,25,0">
                                         <Button
                                            
                                             Content="{Binding LoginLoc}"
-                                            Click="LoginButton_Click" Margin="0,0,7,0" Width="84"
+                                            Click="LoginButton_Click" Margin="0,0,7,0" Width="115"
                                             ToolTip="{Binding LoginTooltipLoc}" />
                                         <Button HorizontalAlignment="Left"
                                                 x:Name="AccountSwitcherButton" Margin="0 0 0 0" Background="#FF0096DB"


### PR DESCRIPTION
This is an attempt to accommodate lengthier languages like French as reported in #296 by tweaking the UI of the main window a little bit. 

![image](https://user-images.githubusercontent.com/59393535/98466839-ab246700-2197-11eb-9579-9c9ff0292635.png)

Looks fine to me just eyeballing it, and doesn't ruin the aesthetic of other languages like English.

![image](https://user-images.githubusercontent.com/59393535/98466859-c5f6db80-2197-11eb-897e-59c573d4f01a.png)
