### PR TITLE
Disable Autologin when OAuth fails

### DIFF
--- a/XIVLauncher/Game/Launcher.cs
+++ b/XIVLauncher/Game/Launcher.cs
@@ -109,9 +109,16 @@ namespace XIVLauncher.Game
                 catch (Exception ex)
                 {
                     Log.Information(ex, "OAuth login failed.");
-                    MessageBox.Show(
-                        "Could not login into your Square Enix account.\nThis could be caused by bad credentials or OTPs.\n\nPlease also check your email inbox for any messages from Square Enix - they might want you to reset your password due to \"suspicious activity\".\nThis is NOT caused by a security issue in XIVLauncher, it is merely a safety measure by Square Enix to prevent logins from new locations, in case your account is getting stolen.\nXIVLauncher and the official launcher will work fine again after resetting your password.",
-                        "Login issue", MessageBoxButton.OK, MessageBoxImage.Error);
+                    var failedOauthMessage = "Could not login into your Square Enix account.\nThis could be caused by bad credentials or OTPs.\n\nPlease also check your email inbox for any messages from Square Enix - they might want you to reset your password due to \"suspicious activity\".\nThis is NOT caused by a security issue in XIVLauncher, it is merely a safety measure by Square Enix to prevent logins from new locations, in case your account is getting stolen.\nXIVLauncher and the official launcher will work fine again after resetting your password.";
+                    if (App.Settings.AutologinEnabled)
+                    {
+                        var result = MessageBox.Show(
+                        failedOauthMessage+"\nAuto-launch has been disabled to allow checking credentials.\nPress OK in order to disable Auto-launch on the next run.",
+                        "Login issue", MessageBoxButton.OKCancel, MessageBoxImage.Error);
+                        if (result == MessageBoxResult.OK) App.Settings.AutologinEnabled = false;
+                        return null;
+                    }
+                    MessageBox.Show(failedOauthMessage,"Login issue", MessageBoxButton.OK, MessageBoxImage.Error);
                     return null;
                 }
 


### PR DESCRIPTION
This is a quick and dirty change to disable the auto login when OAuth fails, the issues that come up from OAuth failing are numerous, but the most common case is that the credentials were typed in wrong. Since many people are not aware of the holding Shift to disable auto login, adding it here to the failure should serve the purpose well.

#342 