### PR TITLE
Improvements to patch downloader, restrict parallel downloads

### DIFF
--- a/XIVLauncher/Game/Patch/PatchManager.cs
+++ b/XIVLauncher/Game/Patch/PatchManager.cs
@@ -51,7 +51,7 @@ namespace XIVLauncher.Game.Patch
                 UserAgent = "FFXIV PATCH CLIENT",
                 Accept = "*/*"
             },
-            MaximumBytesPerSecond = App.Settings.SpeedLimitBytes / MAX_DOWNLOADS_AT_ONCE
+            MaximumBytesPerSecond = App.Settings.SpeedLimitBytes / (App.Settings.DownloadsLimit > 0 ? App.Settings.DownloadsLimit : MAX_DOWNLOADS_AT_ONCE)
         };
 
         public event EventHandler<bool> OnFinish;
@@ -90,8 +90,9 @@ namespace XIVLauncher.Game.Patch
 
             Downloads = patches.Select(patchListEntry => new PatchDownload {Patch = patchListEntry, State = PatchState.Nothing}).ToList().AsReadOnly();
 
+            var numDownloaders = App.Settings.DownloadsLimit > 0 ? App.Settings.DownloadsLimit : MAX_DOWNLOADS_AT_ONCE;
             // All dl slots are available at the start
-            for (var i = 0; i < MAX_DOWNLOADS_AT_ONCE; i++)
+            for (var i = 0; i < numDownloaders; i++)
             {
                 Slots[i] = true;
             }
@@ -193,10 +194,11 @@ namespace XIVLauncher.Game.Patch
 
         private void RunDownloadQueue()
         {
+            var maxDownloads = App.Settings.DownloadsLimit > 0 ? App.Settings.DownloadsLimit : MAX_DOWNLOADS_AT_ONCE;
             while (Downloads.Any(x => x.State == PatchState.Nothing))
             {
                 Thread.Sleep(500);
-                for (var i = 0; i < MAX_DOWNLOADS_AT_ONCE; i++)
+                for (var i = 0; i < maxDownloads; i++)
                 {
                     if (!Slots[i]) 
                         continue;

--- a/XIVLauncher/Settings/ILauncherSettingsV3.cs
+++ b/XIVLauncher/Settings/ILauncherSettingsV3.cs
@@ -28,7 +28,8 @@ namespace XIVLauncher.Settings
         bool? EncryptArguments { get; set; }
         DirectoryInfo PatchPath { get; set; }
         bool? AskBeforePatchInstall { get; set; } 
-        long SpeedLimitBytes { get; set; } 
+        long SpeedLimitBytes { get; set; }
+        int DownloadsLimit { get; set; }
         decimal DalamudInjectionDelayMs { get; set; }
         bool? KeepPatches { get; set; }
         bool? OptOutMbCollection { get; set; }

--- a/XIVLauncher/Windows/PatchDownloadDialog.xaml.cs
+++ b/XIVLauncher/Windows/PatchDownloadDialog.xaml.cs
@@ -6,6 +6,7 @@ using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Timers;
 using System.Windows;
+using System.Windows.Controls;
 using System.Windows.Input;
 using Serilog;
 using XIVLauncher.Game.Patch;
@@ -89,42 +90,24 @@ namespace XIVLauncher.Windows
             switch (index)
             {
                 case 0:
-                    SetProgressBar1Progress(patchName, pct);
+                    SetProgressBarProgress(ref Progress1, ref Progress1Text, patchName, pct);
                     break;
                 case 1:
-                    SetProgressBar2Progress(patchName, pct);
+                    SetProgressBarProgress(ref Progress2, ref Progress2Text, patchName, pct);
                     break;
                 case 2:
-                    SetProgressBar3Progress(patchName, pct);
+                    SetProgressBarProgress(ref Progress3, ref Progress3Text, patchName, pct);
                     break;
                 case 3:
-                    SetProgressBar4Progress(patchName, pct);
+                    SetProgressBarProgress(ref Progress4, ref Progress4Text, patchName, pct);
                     break;
             }
         }
 
-        public void SetProgressBar1Progress(string patchName, double percentage)
+        private static void SetProgressBarProgress(ref ProgressBar pb, ref TextBlock pt, string patchName, double percentage)
         {
-            Progress1.Value = percentage;
-            Progress1Text.Text = patchName;
-        }
-
-        public void SetProgressBar2Progress(string patchName, double percentage)
-        {
-            Progress2.Value = percentage;
-            Progress2Text.Text = patchName;
-        }
-
-        public void SetProgressBar3Progress(string patchName, double percentage)
-        {
-            Progress3.Value = percentage;
-            Progress3Text.Text = patchName;
-        }
-
-        public void SetProgressBar4Progress(string patchName, double percentage)
-        {
-            Progress4.Value = percentage;
-            Progress4Text.Text = patchName;
+            pb.Value = percentage;
+            pt.Text = patchName;
         }
 
         public void SetDownloadDone()

--- a/XIVLauncher/Windows/SettingsControl.xaml
+++ b/XIVLauncher/Windows/SettingsControl.xaml
@@ -211,9 +211,16 @@
 
                     <Label HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="{DynamicResource MaterialDesignBody}" Margin="5,10,0,0"
                            Content="{Binding PatchSpeedLimitLoc}" />
-
                     <StackPanel Orientation="Horizontal">
                         <xctk:DecimalUpDown x:Name="SpeedLimiterUpDown" Margin="10,0,0,0" Width="60" HorizontalAlignment="Left" Value="0"/>
+                        <Label Foreground="{DynamicResource MaterialDesignBody}" Margin="0,0,0,0"
+                               Content="MB/s" />
+                    </StackPanel>
+
+                    <Label HorizontalAlignment="Left" VerticalAlignment="Top" Foreground="{DynamicResource MaterialDesignBody}" Margin="5,10,0,0"
+                           Content="{Binding PatchDownloadsLimitLoc}" />
+                    <StackPanel Orientation="Horizontal">
+                        <xctk:IntegerUpDown x:Name="DownloadsLimiterUpDown" Margin="10,0,0,0" Width="60" HorizontalAlignment="Left" Value="0" Minimum="1" Maximum="4"/>
                         <Label Foreground="{DynamicResource MaterialDesignBody}" Margin="0,0,0,0"
                                Content="MB/s" />
                     </StackPanel>

--- a/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -84,8 +84,9 @@ namespace XIVLauncher.Windows
             EnableHooksCheckBox.Checked += EnableHooksCheckBox_OnChecked;
 
             var val = (decimal) App.Settings.SpeedLimitBytes / BYTES_TO_MB;
-
             SpeedLimiterUpDown.Value = val;
+
+            DownloadsLimiterUpDown.Value = App.Settings.DownloadsLimit > 0 ? App.Settings.DownloadsLimit : 4;
         }
 
         private void AcceptButton_Click(object sender, RoutedEventArgs e)
@@ -120,6 +121,7 @@ namespace XIVLauncher.Windows
             SettingsDismissed?.Invoke(this, null);
 
             App.Settings.SpeedLimitBytes = (long) (SpeedLimiterUpDown.Value * BYTES_TO_MB);
+            App.Settings.DownloadsLimit = (int) DownloadsLimiterUpDown.Value;
         }
 
         private void GitHubButton_OnClick(object sender, RoutedEventArgs e)

--- a/XIVLauncher/Windows/ViewModel/SettingsControlViewModel.cs
+++ b/XIVLauncher/Windows/ViewModel/SettingsControlViewModel.cs
@@ -128,6 +128,7 @@ namespace XIVLauncher.Windows.ViewModel
             AskBeforePatchLoc = Loc.Localize("AskBeforePatch", "Ask before installing a game patch");
             PatchPathLoc = Loc.Localize("PatchPath", "Patch Download Directory");
             PatchSpeedLimitLoc = Loc.Localize("PatchSpeedLimit", "Download Speed Limit");
+            PatchDownloadsLimitLoc = Loc.Localize("PatchDownloadsLimit", "Parallel Downloads Limit");
             KeepPatchesLoc = Loc.Localize("KeepPatches", "Keep downloaded patches for future reinstalls");
 
             SettingsAboutLoc = Loc.Localize("SettingsAbout", "About");
@@ -191,6 +192,7 @@ namespace XIVLauncher.Windows.ViewModel
         public string AskBeforePatchLoc { get; private set; }
         public string PatchPathLoc { get; private set; }
         public string PatchSpeedLimitLoc { get; private set; }
+        public string PatchDownloadsLimitLoc { get; private set; }
         public string KeepPatchesLoc { get; private set; }
 
         public string SettingsAboutLoc { get; private set; }


### PR DESCRIPTION
Starting this early for feedback

- Don't think I would need to shorten the size of the array, but it probably would be more polished
- The UI component is basically the same as download speeds.

This works to resolve #333 