### PR TITLE
Reset UID cache at startup when holding control

### DIFF
--- a/XIVLauncher/Windows/MainWindow.xaml.cs
+++ b/XIVLauncher/Windows/MainWindow.xaml.cs
@@ -193,6 +193,13 @@ namespace XIVLauncher.Windows
 
             AutoLoginCheckBox.IsChecked = App.Settings.AutologinEnabled;
 
+            if (App.Settings.UniqueIdCacheEnabled && Keyboard.Modifiers.HasFlag(ModifierKeys.Control))
+            {
+                UniqueIdCache.Reset();
+                _launcher.Cache.Load();
+                Console.Beep(523, 150); // Feedback without popup
+            }
+
             if (App.Settings.AutologinEnabled && savedAccount != null && !Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
             {
                 Log.Information("Engaging Autologin...");

--- a/XIVLauncher/Windows/SettingsControl.xaml
+++ b/XIVLauncher/Windows/SettingsControl.xaml
@@ -276,6 +276,9 @@
                                 <Button Style="{DynamicResource MaterialDesignFlatButton}"
                                         HorizontalAlignment="Left"
                                         Click="ResetCacheButton_OnClick" Margin="0 0 0 0">
+                                    <Button.ToolTip>
+                                        <TextBlock Text="{Binding ResetUidCacheTipLoc}" />
+                                    </Button.ToolTip>
                                     <StackPanel Orientation="Horizontal">
                                         <TextBlock Margin="0 0 0 0" VerticalAlignment="Center"
                                                    Foreground="DarkGray" FontSize="11">

--- a/XIVLauncher/Windows/UpdateLoadingDialog.xaml
+++ b/XIVLauncher/Windows/UpdateLoadingDialog.xaml
@@ -14,16 +14,17 @@
         Background="Transparent"
         WindowStyle="None" Height="170.088" Width="269.186">
     <Grid Margin="0,0,0,0">
-        <materialDesign:Card Background="{DynamicResource MaterialDesignPaper}" Height="149" Margin="0,0,10,0">
+        <materialDesign:Card x:Name="UpdateLoadingCard" Background="{DynamicResource MaterialDesignPaper}" Height="149" Margin="0,0,10,0">
             <StackPanel Margin="16,16,10,0">
                 <TextBlock Foreground="{DynamicResource MaterialDesignBody}" HorizontalAlignment="Center" Text="{Binding UpdateCheckLoc}"></TextBlock>
 
                 <ProgressBar
                     IsIndeterminate="True" Margin="0,50,0,0" />
 
-                <TextBlock Foreground="DarkGray" Margin="0,35,0,0" TextAlignment="Center" x:Name="AutoLoginDisclaimer" Text="{Binding AutoLoginHintLoc}">
-                    
-                </TextBlock>
+                <Separator Opacity="0" Height="30"/>
+                
+                <TextBlock Foreground="DarkGray" Margin="0,5,0,0" TextAlignment="Center" x:Name="AutoLoginDisclaimer" Text="{Binding AutoLoginHintLoc}"></TextBlock>
+                <TextBlock Foreground="DarkGray" Margin="0,5,0,0" TextAlignment="Center" x:Name="ResetUidCacheDisclaimer" Text="{Binding ResetUidCacheHintLoc}"></TextBlock>
             </StackPanel>
         </materialDesign:Card>
     </Grid>

--- a/XIVLauncher/Windows/UpdateLoadingDialog.xaml.cs
+++ b/XIVLauncher/Windows/UpdateLoadingDialog.xaml.cs
@@ -20,7 +20,13 @@ namespace XIVLauncher.Windows
         {
             InitializeComponent();
 
-            AutoLoginDisclaimer.Visibility = App.Settings.AutologinEnabled ? Visibility.Visible : Visibility.Hidden;
+            AutoLoginDisclaimer.Visibility = App.Settings.AutologinEnabled ? Visibility.Visible : Visibility.Collapsed;
+            ResetUidCacheDisclaimer.Visibility = App.Settings.UniqueIdCacheEnabled ? Visibility.Visible : Visibility.Collapsed;
+            if (ResetUidCacheDisclaimer.Visibility == Visibility.Visible
+                && AutoLoginDisclaimer.Visibility == Visibility.Visible) {
+                UpdateLoadingCard.Height += 19;
+            }
+
             this.DataContext = new UpdateLoadingDialogViewModel();
         }
     }

--- a/XIVLauncher/Windows/ViewModel/SettingsControlViewModel.cs
+++ b/XIVLauncher/Windows/ViewModel/SettingsControlViewModel.cs
@@ -136,7 +136,8 @@ namespace XIVLauncher.Windows.ViewModel
             JoinDiscordLoc = Loc.Localize("JoinDiscord", "Join Discord");
             StartBackupToolLoc = Loc.Localize("StartBackupTool", "Start Backup Tool");
             StartOriginalLauncherLoc = Loc.Localize("StartOriginalLauncher", "Start Original Launcher");
-            EnabledUidCacheLoc = Loc.Localize("EnabledUidCache", "Enable experimental UID cache(this will break on game updates!)");
+            EnabledUidCacheLoc = Loc.Localize("EnabledUidCache", "Enable experimental UID cache (this will break on game updates!)");
+            ResetUidCacheTipLoc = Loc.Localize("ResetUidCacheTip", "Hold control while starting the launcher to reset the UID cache");
             EnableEncryptionLoc = Loc.Localize("EnableEncryption", "Enable encrypting arguments to the client");
         }
 
@@ -199,6 +200,7 @@ namespace XIVLauncher.Windows.ViewModel
         public string StartBackupToolLoc { get; private set; }
         public string StartOriginalLauncherLoc { get; private set; }
         public string EnabledUidCacheLoc { get; private set; }
+        public string ResetUidCacheTipLoc { get; private set; }
         public string EnableEncryptionLoc { get; private set; }
     }
 }

--- a/XIVLauncher/Windows/ViewModel/UpdateLoadingDialogViewModel.cs
+++ b/XIVLauncher/Windows/ViewModel/UpdateLoadingDialogViewModel.cs
@@ -18,9 +18,11 @@ namespace XIVLauncher.Windows.ViewModel
         {
             UpdateCheckLoc = Loc.Localize("UpdateCheckMsg", "Checking for updates...");
             AutoLoginHintLoc = Loc.Localize("AutoLoginHint", "Hold the shift key to change settings!");
+            ResetUidCacheHintLoc = Loc.Localize("ResetUidCacheHint", "Hold the control key to reset UID cache!");
         }
 
         public string UpdateCheckLoc { get; private set; }
         public string AutoLoginHintLoc { get; private set; }
+        public string ResetUidCacheHintLoc { get; private set; }
     }
 }


### PR DESCRIPTION
I started using the UID cache recently and having to reset it in the settings is a bit annoying when you know it won't be valid or if you want to force reset the timer.
Chose control as it's close to shift and shouldn't randomly happen when starting the launcher.

If both auto login and UID cache are enabled, the update window is a bit higher, not sure if you want to keep the size exactly the same or if you don't care.

![update](https://i.imgur.com/b3MRAGd.png)