### PR TITLE
Load SavePassword state on ContextMenu open

### DIFF
--- a/XIVLauncher/Windows/AccountSwitcher.xaml
+++ b/XIVLauncher/Windows/AccountSwitcher.xaml
@@ -19,11 +19,11 @@
             <StackPanel Margin="16,16,10,0">
                 <ListView x:Name="AccountListView" MouseUp="AccountListView_OnMouseUp" MaxHeight="370">
                     <ListView.ContextMenu>
-                        <ContextMenu StaysOpen="true">
+                        <ContextMenu Opened="AccountListViewContext_Opened" StaysOpen="true">
                             <MenuItem Header="{Binding AccountSwitcherSetProfilePicLoc}" Click="SetProfilePicture_OnClick"  Foreground="{DynamicResource MaterialDesignBody}"/>
                             <MenuItem Header="{Binding AccountSwitcherCreateShortcutLoc}" Click="CreateDesktopShortcut_OnClick" Foreground="{DynamicResource MaterialDesignBody}"/>
                             <MenuItem Header="{Binding RemoveLoc}" Click="RemoveAccount_OnClick" Foreground="{DynamicResource MaterialDesignBody}"/>
-                            <MenuItem IsCheckable="True" Header="{Binding AccountSwitcherDontSavePasswordLoc}" Checked="DontSavePassword_OnChecked" Unchecked="DontSavePassword_OnUnchecked" Foreground="{DynamicResource MaterialDesignBody}"/>
+                            <MenuItem x:Name="AccountEntrySavePasswordCheck" IsCheckable="True" Header="{Binding AccountSwitcherDontSavePasswordLoc}" Checked="DontSavePassword_OnChecked" Unchecked="DontSavePassword_OnUnchecked" Foreground="{DynamicResource MaterialDesignBody}"/>
                         </ContextMenu>
                     </ListView.ContextMenu>
 

--- a/XIVLauncher/Windows/AccountSwitcher.xaml.cs
+++ b/XIVLauncher/Windows/AccountSwitcher.xaml.cs
@@ -77,6 +77,12 @@ namespace XIVLauncher.Windows
             Close();
         }
 
+        private void AccountListViewContext_Opened(object sender, RoutedEventArgs e)
+        {
+            var selectedEntry = AccountListView.SelectedItem as AccountSwitcherEntry;
+            AccountEntrySavePasswordCheck.IsChecked = !selectedEntry.Account.SavePassword;
+        }
+
         private void AccountSwitcher_OnDeactivated(object sender, EventArgs e)
         {
             if (!_closing)


### PR DESCRIPTION
This fixes #358 , the state of the setting is loaded when the context menu is opened