### PR TITLE
Don't start patcher in admin mode if user has write access to folder 

### DIFF
--- a/XIVLauncher/Game/Patch/PatchInstaller.cs
+++ b/XIVLauncher/Game/Patch/PatchInstaller.cs
@@ -37,7 +37,7 @@ namespace XIVLauncher.Game.Patch
 
         public InstallerState State { get; private set; } = InstallerState.NotStarted;
 
-        public void StartIfNeeded()
+        public void StartIfNeeded(bool needAdminRights = true)
         {
             if (State != InstallerState.NotStarted)
                 return;
@@ -51,8 +51,8 @@ namespace XIVLauncher.Game.Patch
             var startInfo = new ProcessStartInfo(path);
             startInfo.UseShellExecute = true;
 
-            //Start as admin
-            if (System.Environment.OSVersion.Version.Major >= 6)
+            //Start as admin if needed
+            if (needAdminRights && System.Environment.OSVersion.Version.Major >= 6)
             {
                 startInfo.Verb = "runas";
             }

--- a/XIVLauncher/Game/Patch/PatchManager.cs
+++ b/XIVLauncher/Game/Patch/PatchManager.cs
@@ -122,8 +122,20 @@ namespace XIVLauncher.Game.Patch
                 return;
             }
 #endif
+            // Check if user needs admin rights to start patcher (inspired by: https://stackoverflow.com/questions/1410127/c-sharp-test-if-user-has-write-access-to-a-folder)
+            bool needAdminRights = true;
 
-            _installer.StartIfNeeded();
+            try
+            {
+                // will throw exception if user does not have admin rights to write on game folder
+                _gamePath.GetAccessControl();
+                needAdminRights = false;
+            } catch (UnauthorizedAccessException)
+            {
+                needAdminRights = true;
+            }
+
+            _installer.StartIfNeeded(needAdminRights);
             _installer.WaitOnHello();
 
             Task.Run(RunDownloadQueue, _cancelTokenSource.Token);


### PR DESCRIPTION
Self-explanatory, useful if trying to install FFXIV on a computer where you don't have admin rights