### PR TITLE
Don't start patcher with admin rights if XL_NO_RUNAS is set in environment variables

### DIFF
--- a/XIVLauncher/Game/Patch/PatchInstaller.cs
+++ b/XIVLauncher/Game/Patch/PatchInstaller.cs
@@ -51,11 +51,9 @@ namespace XIVLauncher.Game.Patch
             var startInfo = new ProcessStartInfo(path);
             startInfo.UseShellExecute = true;
 
-            //Start as admin
-            if (System.Environment.OSVersion.Version.Major >= 6)
-            {
+            //Start as admin if needed
+            if (!EnvironmentSettings.NoRunas && System.Environment.OSVersion.Version.Major >= 6)
                 startInfo.Verb = "runas";
-            }
 
             State = InstallerState.NotReady;
 

--- a/XIVLauncher/Game/Patch/PatchInstaller.cs
+++ b/XIVLauncher/Game/Patch/PatchInstaller.cs
@@ -52,7 +52,7 @@ namespace XIVLauncher.Game.Patch
             startInfo.UseShellExecute = true;
 
             //Start as admin if needed
-            if (!EnvironmentSettings.NoRunas && System.Environment.OSVersion.Version.Major >= 6)
+            if (!EnvironmentSettings.IsNoRunas && System.Environment.OSVersion.Version.Major >= 6)
                 startInfo.Verb = "runas";
 
             State = InstallerState.NotReady;

--- a/XIVLauncher/Settings/EnvironmentSettings.cs
+++ b/XIVLauncher/Settings/EnvironmentSettings.cs
@@ -11,7 +11,7 @@ namespace XIVLauncher
         public static bool IsWine => CheckEnvBool("XL_WINEONLINUX");
         public static bool IsDisableUpdates => CheckEnvBool("XL_NOAUTOUPDATE");
         public static bool IsPreRelease => CheckEnvBool("XL_PRERELEASE");
-        public static bool NoRunas => CheckEnvBool("XL_NO_RUNAS");
+        public static bool IsNoRunas => CheckEnvBool("XL_NO_RUNAS");
         private static bool CheckEnvBool(string var) => bool.Parse(System.Environment.GetEnvironmentVariable(var) ?? "false");
     }
 }

--- a/XIVLauncher/Settings/EnvironmentSettings.cs
+++ b/XIVLauncher/Settings/EnvironmentSettings.cs
@@ -11,6 +11,7 @@ namespace XIVLauncher
         public static bool IsWine => CheckEnvBool("XL_WINEONLINUX");
         public static bool IsDisableUpdates => CheckEnvBool("XL_NOAUTOUPDATE");
         public static bool IsPreRelease => CheckEnvBool("XL_PRERELEASE");
+        public static bool NoRunas => CheckEnvBool("XL_NO_RUNAS");
         private static bool CheckEnvBool(string var) => bool.Parse(System.Environment.GetEnvironmentVariable(var) ?? "false");
     }
 }


### PR DESCRIPTION
If for some reason the user needs the patcher to not start with admin rights, they can now set an environment variable in order to do so