### PR TITLE
Support for patch download checks

### DIFF
--- a/XIVLauncher/Game/Patch/PatchManager.cs
+++ b/XIVLauncher/Game/Patch/PatchManager.cs
@@ -105,14 +105,6 @@ namespace XIVLauncher.Game.Patch
 #if !DEBUG
             var freeSpaceDownload = (long)Util.GetDiskFreeSpace(_patchStore.Root.FullName);
 
-            if ( (AllDownloadsLength * 1000) > freeSpaceDownload)
-            {
-                OnFinish?.Invoke(this, false);
-
-                MessageBox.Show(string.Format(Loc.Localize("FreeSpaceError", "There is not enough space on your drive to download patches.\n\nYou can change the location patches are downloaded to in the settings.\n\nRequired:{0}\nFree:{1}"), Util.BytesToString(Downloads.OrderByDescending(x => x.Patch.Length).First().Patch.Length), Util.BytesToString(freeSpaceDownload)), "XIVLauncher Error", MessageBoxButton.OK, MessageBoxImage.Error);
-                return;
-            }
-
             if (Downloads.Any(x => x.Patch.Length > freeSpaceDownload))
             {
                 OnFinish?.Invoke(this, false);

--- a/XIVLauncher/Game/Patch/PatchManager.cs
+++ b/XIVLauncher/Game/Patch/PatchManager.cs
@@ -135,14 +135,13 @@ namespace XIVLauncher.Game.Patch
             _installer.StartIfNeeded();
             _installer.WaitOnHello();
 
-            var freeSpaceDownload = (long)Util.GetDiskFreeSpace(_patchStore.Root.FullName);
+            var freeSpaceDownloadAll = (long)Util.GetDiskFreeSpace(_patchStore.Root.FullName);
 
-            Log.Information($"Free Space: {freeSpaceDownload} - Download Length: {AllDownloadsLength}");
-            if ((AllDownloadsLength) > freeSpaceDownload)
+            if ((AllDownloadsLength) > freeSpaceDownloadAll)
             {
                 OnFinish?.Invoke(this, false);
 
-                MessageBox.Show(string.Format(Loc.Localize("FreeSpaceError", "There is not enough space on your drive to download all patches.\n\nYou can change the location patches are downloaded to in the xivlauncher settings, patch section.\n\nRequired:{0}\nFree:{1}"), Util.BytesToString(AllDownloadsLength), Util.BytesToString(freeSpaceDownload)), "XIVLauncher Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                MessageBox.Show(string.Format(Loc.Localize("FreeSpaceError", "There is not enough space on your drive to download all patches.\n\nYou can change the location patches are downloaded to in the xivlauncher settings, patch section.\n\nRequired:{0}\nFree:{1}"), Util.BytesToString(AllDownloadsLength), Util.BytesToString(freeSpaceDownloadAll)), "XIVLauncher Error", MessageBoxButton.OK, MessageBoxImage.Error);
                 return;
             }
 

--- a/XIVLauncher/XIVLauncher.csproj
+++ b/XIVLauncher/XIVLauncher.csproj
@@ -94,8 +94,8 @@
     <Reference Include="DeltaCompressionDotNet.PatchApi, Version=1.1.0.0, Culture=neutral, PublicKeyToken=3e8888ee913ed789, processorArchitecture=MSIL">
       <HintPath>..\packages\DeltaCompressionDotNet.1.1.0\lib\net20\DeltaCompressionDotNet.PatchApi.dll</HintPath>
     </Reference>
-    <Reference Include="Downloader, Version=1.3.0.0, Culture=neutral, PublicKeyToken=844973e732f6cdf4, processorArchitecture=MSIL">
-      <HintPath>..\packages\Downloader.1.3.0\lib\netstandard2.0\Downloader.dll</HintPath>
+    <Reference Include="Downloader, Version=1.7.0.0, Culture=neutral, PublicKeyToken=844973e732f6cdf4, processorArchitecture=MSIL">
+      <HintPath>..\packages\Downloader.1.7.0\lib\netstandard2.0\Downloader.dll</HintPath>
     </Reference>
     <Reference Include="Dragablz, Version=0.0.3.203, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\Dragablz.0.0.3.203\lib\net45\Dragablz.dll</HintPath>

--- a/XIVLauncher/packages.config
+++ b/XIVLauncher/packages.config
@@ -6,7 +6,7 @@
   <package id="Config.Net" version="4.14.23" targetFramework="net471" />
   <package id="Config.Net.Json" version="4.14.23" targetFramework="net471" />
   <package id="DeltaCompressionDotNet" version="1.1.0" targetFramework="net471" />
-  <package id="Downloader" version="1.3.0" targetFramework="net472" />
+  <package id="Downloader" version="1.7.0" targetFramework="net472" />
   <package id="Dragablz" version="0.0.3.203" targetFramework="net461" />
   <package id="Extended.Wpf.Toolkit" version="3.5.0" targetFramework="net462" />
   <package id="MaterialDesignColors" version="1.1.2" targetFramework="net462" />


### PR DESCRIPTION
Adds support for some additional patch download checks, even on debug builds.

Downloader library updated to 1.7.0 which is new enough to support their temp directory override, but not have breaking changes.

Added a disk space check that will check for enough space for ALL patches destined for the patch folder, because we can't guarantee they'll download in order. (And often on a base game install, they absolutely won't).

Should make the user in https://github.com/goatcorp/FFXIVQuickLauncher/issues/380 happy too.