### PR TITLE
Make WINE happy again.

### DIFF
--- a/XIVLauncher/Game/Patch/PatchInstaller.cs
+++ b/XIVLauncher/Game/Patch/PatchInstaller.cs
@@ -27,8 +27,8 @@ namespace XIVLauncher.Game.Patch
         private IpcServer _server = new IpcServer();
         private IpcClient _client = new IpcClient();
 
-        public const int DEFAULT_IPC_SERVER_PORT = 0x114;
-        public const int DEFAULT_IPC_CLIENT_PORT = 0x115;
+        public const int DEFAULT_IPC_SERVER_PORT = 0xff16;
+        public const int DEFAULT_IPC_CLIENT_PORT = 0xff30;
 
         private int _serverPort;
         private int _clientPort;


### PR DESCRIPTION
Make WINE work with one small trick. Everyone hates him! 

Using ports over 1024 makes it happy again. This reverts the defaults back to what they were before and suddenly patching on Linux is fine.