### PR TITLE
add: file hash check if contained in assets.json

### DIFF
--- a/XIVLauncher/Dalamud/AssetManager.cs
+++ b/XIVLauncher/Dalamud/AssetManager.cs
@@ -8,6 +8,8 @@ using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Serilog;
 using XIVLauncher.Windows;
+using System.Security.Cryptography;
+using NuGet;
 
 namespace XIVLauncher.Dalamud
 {
@@ -24,12 +26,14 @@ namespace XIVLauncher.Dalamud
             {
                 public string Url { get; set; }
                 public string FileName { get; set; }
+                public string Hash { get; set; }
             }
         }
 
         public static bool EnsureAssets(DirectoryInfo baseDir)
         {
             using var client = new WebClient();
+            var sha1 = SHA1.Create();
 
             Log.Verbose("[DASSET] Starting asset download");
 
@@ -44,7 +48,8 @@ namespace XIVLauncher.Dalamud
 
                 Directory.CreateDirectory(Path.GetDirectoryName(filePath));
 
-                if (!File.Exists(filePath) || isRefreshNeeded)
+                var fileHash = sha1.ComputeHash(File.OpenRead(filePath).ReadAllBytes());
+                if (!File.Exists(filePath) || isRefreshNeeded || entry.Hash.Length > 0 && fileHash.ToString() != entry.Hash)
                 {
                     Log.Verbose("[DASSET] Downloading {0} to {1}...", entry.Url, entry.FileName);
                     try


### PR DESCRIPTION
This fixes #419 for files that have their HASH computed.

### When asset doesn't exist re-download asset, no hash check
```
2021-04-23 17:39:11.291 -04:00 [INF] Trying to set up Loc for language code en
2021-04-23 17:39:11.377 -04:00 [INF] XIVLauncher started as xivlauncher-5.4.0.0-db5cc35-dirty
2021-04-23 17:39:11.418 -04:00 [INF] Loading MainWindow for account ''
2021-04-23 17:39:12.604 -04:00 [INF] MainWindow initialized.
2021-04-23 17:39:12.801 -04:00 [INF] [DUPDATE] Starting...
2021-04-23 17:39:12.861 -04:00 [INF] [DUPDATE] Now starting for Dalamud 5.2.5.8
2021-04-23 17:39:12.868 -04:00 [VRB] [DASSET] Starting asset download
2021-04-23 17:39:12.890 -04:00 [VRB] [DASSET] Ver check - local:17 remote:17
2021-04-23 17:39:12.926 -04:00 [VRB] [DASSET] UIRes/NotoSansCJKjp-Medium.otf has hash 7334F0BADA3A7D52E1C642217EB7EA21BE700421 when remote asset has 7334F0BADA3A7D52E1C642217EB7EA21BE700421.
2021-04-23 17:39:12.927 -04:00 [VRB] [DASSET] UIRes/FontAwesome5FreeSolid.otf has hash 893A372F71B73FA3A58A02CFDA43A7B34CDA337A when remote asset has 893A372F71B73FA3A58A02CFDA43A7B34CDA337A.
2021-04-23 17:39:12.928 -04:00 [VRB] [DASSET] Downloading https://goatcorp.github.io/DalamudAssets/UIRes/logo.png to UIRes/logo.png...
2021-04-23 17:39:12.980 -04:00 [VRB] [DASSET] UIRes/gamesym.ttf has hash 89BC6B5015EF0EDFA5AE272B3A406B54CF61C6F1 when remote asset has 89BC6B5015EF0EDFA5AE272B3A406B54CF61C6F1.
2021-04-23 17:39:12.980 -04:00 [VRB] [DASSET] Assets OK
2021-04-23 17:39:12.982 -04:00 [INF] [DUPDATE] All set for 2021.04.07.0000.0000
```

### When asset has mismatching hash, re-download
```
2021-04-23 17:41:02.640 -04:00 [INF] Trying to set up Loc for language code en
2021-04-23 17:41:02.726 -04:00 [INF] XIVLauncher started as xivlauncher-5.4.0.0-db5cc35-dirty
2021-04-23 17:41:02.766 -04:00 [INF] Loading MainWindow for account ''
2021-04-23 17:41:03.971 -04:00 [INF] MainWindow initialized.
2021-04-23 17:41:04.172 -04:00 [INF] [DUPDATE] Starting...
2021-04-23 17:41:04.235 -04:00 [INF] [DUPDATE] Now starting for Dalamud 5.2.5.8
2021-04-23 17:41:04.242 -04:00 [VRB] [DASSET] Starting asset download
2021-04-23 17:41:04.261 -04:00 [VRB] [DASSET] Ver check - local:17 remote:17
2021-04-23 17:41:04.297 -04:00 [VRB] [DASSET] UIRes/NotoSansCJKjp-Medium.otf has hash 7334F0BADA3A7D52E1C642217EB7EA21BE700421 when remote asset has 7334F0BADA3A7D52E1C642217EB7EA21BE700421.
2021-04-23 17:41:04.298 -04:00 [VRB] [DASSET] UIRes/FontAwesome5FreeSolid.otf has hash 893A372F71B73FA3A58A02CFDA43A7B34CDA337A when remote asset has 893A372F71B73FA3A58A02CFDA43A7B34CDA337A.
2021-04-23 17:41:04.302 -04:00 [VRB] [DASSET] UIRes/logo.png has hash A5D0AF161A76487E677DBC017F7F6D91958C5CA6 when remote asset has AEFA0F4FB7A15391CE210142015ABFD753D803C9.
2021-04-23 17:41:04.303 -04:00 [VRB] [DASSET] Downloading https://goatcorp.github.io/DalamudAssets/UIRes/logo.png to UIRes/logo.png...
2021-04-23 17:41:04.350 -04:00 [VRB] [DASSET] UIRes/gamesym.ttf has hash 89BC6B5015EF0EDFA5AE272B3A406B54CF61C6F1 when remote asset has 89BC6B5015EF0EDFA5AE272B3A406B54CF61C6F1.
2021-04-23 17:41:04.350 -04:00 [VRB] [DASSET] Assets OK
2021-04-23 17:41:04.355 -04:00 [INF] [DUPDATE] All set for 2021.04.07.0000.0000
```

### When all assets are okay
```
2021-04-23 17:42:50.272 -04:00 [INF] Trying to set up Loc for language code en
2021-04-23 17:42:50.359 -04:00 [INF] XIVLauncher started as xivlauncher-5.4.0.0-db5cc35-dirty
2021-04-23 17:42:50.402 -04:00 [INF] Loading MainWindow for account ''
2021-04-23 17:42:51.587 -04:00 [INF] MainWindow initialized.
2021-04-23 17:42:51.790 -04:00 [INF] [DUPDATE] Starting...
2021-04-23 17:42:51.854 -04:00 [INF] [DUPDATE] Now starting for Dalamud 5.2.5.8
2021-04-23 17:42:51.862 -04:00 [VRB] [DASSET] Starting asset download
2021-04-23 17:42:51.881 -04:00 [VRB] [DASSET] Ver check - local:17 remote:17
2021-04-23 17:42:51.916 -04:00 [VRB] [DASSET] UIRes/NotoSansCJKjp-Medium.otf has hash 7334F0BADA3A7D52E1C642217EB7EA21BE700421 when remote asset has 7334F0BADA3A7D52E1C642217EB7EA21BE700421.
2021-04-23 17:42:51.917 -04:00 [VRB] [DASSET] UIRes/FontAwesome5FreeSolid.otf has hash 893A372F71B73FA3A58A02CFDA43A7B34CDA337A when remote asset has 893A372F71B73FA3A58A02CFDA43A7B34CDA337A.
2021-04-23 17:42:51.918 -04:00 [VRB] [DASSET] UIRes/logo.png has hash AEFA0F4FB7A15391CE210142015ABFD753D803C9 when remote asset has AEFA0F4FB7A15391CE210142015ABFD753D803C9.
2021-04-23 17:42:51.919 -04:00 [VRB] [DASSET] UIRes/gamesym.ttf has hash 89BC6B5015EF0EDFA5AE272B3A406B54CF61C6F1 when remote asset has 89BC6B5015EF0EDFA5AE272B3A406B54CF61C6F1.
2021-04-23 17:42:51.919 -04:00 [VRB] [DASSET] Assets OK
2021-04-23 17:42:51.923 -04:00 [INF] [DUPDATE] All set for 2021.04.07.0000.0000
```
