### PR TITLE
fix: disable autologin, show main window when password is blank

### DIFF
--- a/XIVLauncher/Windows/MainWindow.xaml.cs
+++ b/XIVLauncher/Windows/MainWindow.xaml.cs
@@ -360,6 +360,12 @@ namespace XIVLauncher.Windows
                 CustomMessageBox.Show(
                     Loc.Localize("EmptyPasswordError", "Please enter a password."),
                     "XIVLauncher", MessageBoxButton.OK, MessageBoxImage.Error);
+                _isLoggingIn = false;
+                App.Settings.AutologinEnabled = false;
+                AutoLoginCheckBox.IsChecked = false;
+                _ = Task.Run(SetupHeadlines);
+                Show();
+                Activate();
                 return;
             }
 


### PR DESCRIPTION
This is for #415 , if the password isNullorEmpty, disable auto-login and show the main window again for user to re-enter their password
