### PR TITLE
Modify ci-workflow.yml to automate creating releases

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -56,6 +56,7 @@ jobs:
         with:
           files: Releases\**
           name: Release ${{ steps.build-squirrel.outputs.version }}
+          body_path:  RELEASE.md
       - name: Upload artifact
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -29,6 +29,33 @@ jobs:
         run: |
           cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
            .\MSBuild.exe $Env:GITHUB_WORKSPACE\XIVLauncher.sln /t:Build /p:Configuration=ReleaseNoUpdate
+      - name: Build Squirrel Release
+        id: build-squirrel
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          $baseuri = 'https://github.com/goatcorp/FFXIVQuickLauncher/releases/latest/download' 
+          $refver = $env:GITHUB_REF -replace '.*/'
+          echo "::set-output name=version::$refver"
+          nuget pack .\XIVLauncher.nuspec -properties version=$refver
+          mkdir Releases
+          Invoke-WebRequest -Uri $baseuri/RELEASES -OutFile .\Releases\RELEASES
+          $latest = Select-String -Path "Releases\RELEASES" -Pattern "XIVLauncher-(.*)-.*.nupkg" | Select-Object * -Last 1
+          $ver = $latest.Matches.groups[1].value
+          Invoke-WebRequest -Uri $baseuri/XIVLauncher-$ver-delta.nupkg -OutFile .\Releases\XIVLauncher-$ver-delta.nupkg
+          Invoke-WebRequest -Uri $baseuri/XIVLauncher-$ver-full.nupkg -OutFile .\Releases\XIVLauncher-$ver-full.nupkg
+          Invoke-WebRequest -Uri $baseuri/Setup.exe -OutFile .\Releases\Setup.exe
+           ~\.nuget\packages\squirrel.windows\1.9.1\tools\Squirrel.exe --no-msi --releasify .\XIVLauncher.$refver.nupkg
+          Start-Sleep -s 30
+          rm .\Releases\XIVLauncher-$ver-delta.nupkg
+          rm .\Releases\XIVLauncher-$ver-full.nupkg
+      - name: Create Release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: Releases\**
+          name: Release ${{ steps.build-squirrel.outputs.version }}
       - name: Upload artifact
         uses: actions/upload-artifact@master
         with:

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,0 +1,8 @@
+﻿This is a maintenance release.
+
+- Fixes an issue wherein,
+
+**:warning: Attention!**
+If you receive errors during the installation or if the launcher doesn't work correctly, make sure to check your antivirus first and disable it for XIVLauncher. Many commercial antivirus programs detect XIVLauncher as a false positive. You can check for yourself on VirusTotal.
+
+**Please download ``Setup.exe`` from below to install XIVLauncher, if you have not used it before.**

--- a/XIVLauncher.nuspec
+++ b/XIVLauncher.nuspec
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<package xmlns="http://schemas.microsoft.com/packaging/2010/07/nuspec.xsd">
+  <metadata>
+    <id>XIVLauncher</id>
+    <version>$version$</version>
+    <title>XIVLauncher</title>
+    <authors>goaaats</authors>
+    <owners>goaaats</owners>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <projectUrl>https://github.com/goaaats/FFXIVQuickLauncher</projectUrl>
+    <iconUrl>https://raw.githubusercontent.com/goaaats/FFXIVQuickLauncher/master/XIVLauncher/Resources/dalamud_icon.ico</iconUrl>
+    <description>Custom launcher for FINAL FANTASY XIV</description>
+  </metadata>
+
+  <files>
+    <file src="bin\**" target="lib\net45" />
+  </files>
+</package>


### PR DESCRIPTION
This automates the process of creating new releases for XIVLauncher, currently only triggers on tags, and the description of the release will need to get updated after the action is complete.

Example of a completed run:
![image](https://user-images.githubusercontent.com/5796109/116444199-7ded7300-a822-11eb-837b-8e2fb0bf1ed4.png)

