### PR TITLE
fix: use correct release mode depending on build

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -2,6 +2,60 @@ name: Build XIVLauncher
 on: [push, pull_request]
 
 jobs:
+  build-release:
+    name: Build Relase on Windows
+    if: startsWith(github.ref, 'refs/tags/')
+    runs-on: windows-2019
+    steps:
+      - uses: actions/checkout@v1
+      - name: Initialize Submodules
+        run: git submodule update --init --recursive
+      - name: Setup Nuget
+        uses: nuget/setup-nuget@v1
+        with:
+          nuget-version: "latest"
+      - name: Restore Nuget Packages
+        run: nuget restore XIVLauncher.sln
+      - name: Define VERSION
+        run: |
+          $env:COMMIT = $env:GITHUB_SHA.Substring(0, 7)
+          $env:REPO_NAME = $env:GITHUB_REPOSITORY -replace '.*/'
+          $env:BRANCH = $env:GITHUB_REF -replace '.*/'
+
+          ($env:REPO_NAME) >> VERSION
+          ($env:BRANCH) >> VERSION
+          ($env:COMMIT) >> VERSION
+      - name: Build DotNet4 for Release
+        run: |
+          cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\XIVLauncher.sln /t:Build /p:Configuration=Release
+      - name: Build Squirrel Release
+        id: build-squirrel
+        run: |
+          $baseuri = 'https://github.com/goatcorp/FFXIVQuickLauncher/releases/latest/download' 
+          $refver = $env:GITHUB_REF -replace '.*/'
+          echo "::set-output name=version::$refver"
+          nuget pack .\XIVLauncher.nuspec -properties version=$refver
+          mkdir Releases
+          Invoke-WebRequest -Uri $baseuri/RELEASES -OutFile .\Releases\RELEASES
+          $latest = Select-String -Path "Releases\RELEASES" -Pattern "XIVLauncher-(.*)-.*.nupkg" | Select-Object * -Last 1
+          $ver = $latest.Matches.groups[1].value
+          Invoke-WebRequest -Uri $baseuri/XIVLauncher-$ver-delta.nupkg -OutFile .\Releases\XIVLauncher-$ver-delta.nupkg
+          Invoke-WebRequest -Uri $baseuri/XIVLauncher-$ver-full.nupkg -OutFile .\Releases\XIVLauncher-$ver-full.nupkg
+          Invoke-WebRequest -Uri $baseuri/Setup.exe -OutFile .\Releases\Setup.exe
+           ~\.nuget\packages\squirrel.windows\1.9.1\tools\Squirrel.exe --no-msi --releasify .\XIVLauncher.$refver.nupkg
+          Start-Sleep -s 30
+          rm .\Releases\XIVLauncher-$ver-delta.nupkg
+          rm .\Releases\XIVLauncher-$ver-full.nupkg
+      - name: Create Release
+        uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          files: Releases\**
+          name: Release ${{ steps.build-squirrel.outputs.version }}
+          body_path:  RELEASE.md
+          prerelease: true
   build:
     name: Build on Windows
     runs-on: windows-2019
@@ -25,44 +79,9 @@ jobs:
           ($env:BRANCH) >> VERSION
           ($env:COMMIT) >> VERSION
       - name: Build DotNet4 Master
-        if: "!(startsWith(github.ref, 'refs/tags/'))"
         run: |
           cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
            .\MSBuild.exe $Env:GITHUB_WORKSPACE\XIVLauncher.sln /t:Build /p:Configuration=ReleaseNoUpdate
-      - name: Build DotNet4 for Release
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
-           .\MSBuild.exe $Env:GITHUB_WORKSPACE\XIVLauncher.sln /t:Build /p:Configuration=Release
-      - name: Build Squirrel Release
-        id: build-squirrel
-        if: startsWith(github.ref, 'refs/tags/')
-        run: |
-          $baseuri = 'https://github.com/goatcorp/FFXIVQuickLauncher/releases/latest/download' 
-          $refver = $env:GITHUB_REF -replace '.*/'
-          echo "::set-output name=version::$refver"
-          nuget pack .\XIVLauncher.nuspec -properties version=$refver
-          mkdir Releases
-          Invoke-WebRequest -Uri $baseuri/RELEASES -OutFile .\Releases\RELEASES
-          $latest = Select-String -Path "Releases\RELEASES" -Pattern "XIVLauncher-(.*)-.*.nupkg" | Select-Object * -Last 1
-          $ver = $latest.Matches.groups[1].value
-          Invoke-WebRequest -Uri $baseuri/XIVLauncher-$ver-delta.nupkg -OutFile .\Releases\XIVLauncher-$ver-delta.nupkg
-          Invoke-WebRequest -Uri $baseuri/XIVLauncher-$ver-full.nupkg -OutFile .\Releases\XIVLauncher-$ver-full.nupkg
-          Invoke-WebRequest -Uri $baseuri/Setup.exe -OutFile .\Releases\Setup.exe
-           ~\.nuget\packages\squirrel.windows\1.9.1\tools\Squirrel.exe --no-msi --releasify .\XIVLauncher.$refver.nupkg
-          Start-Sleep -s 30
-          rm .\Releases\XIVLauncher-$ver-delta.nupkg
-          rm .\Releases\XIVLauncher-$ver-full.nupkg
-      - name: Create Release
-        uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
-        if: startsWith(github.ref, 'refs/tags/')
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          files: Releases\**
-          name: Release ${{ steps.build-squirrel.outputs.version }}
-          body_path:  RELEASE.md
-          prerelease: true
       - name: Upload artifact
         uses: actions/upload-artifact@master
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -24,8 +24,13 @@ jobs:
           ($env:REPO_NAME) >> VERSION
           ($env:BRANCH) >> VERSION
           ($env:COMMIT) >> VERSION
-
-      - name: Build DotNet4
+      - name: Build DotNet4 Master
+        if: "!(startsWith(github.ref, 'refs/tags/'))"
+        run: |
+          cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
+           .\MSBuild.exe $Env:GITHUB_WORKSPACE\XIVLauncher.sln /t:Build /p:Configuration=ReleaseNoUpdate
+      - name: Build DotNet4 for Release
+        if: startsWith(github.ref, 'refs/tags/')
         run: |
           cd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\MSBuild\Current\Bin\"
            .\MSBuild.exe $Env:GITHUB_WORKSPACE\XIVLauncher.sln /t:Build /p:Configuration=Release


### PR DESCRIPTION
This will build the launcher in the correct Configuration so that:
- master branch: ReleaseNoUpdate
- tags: Release