### PR TITLE
fix: correctly handle spaces in OTP window

### DIFF
--- a/XIVLauncher/Windows/OtpInputDialog.xaml
+++ b/XIVLauncher/Windows/OtpInputDialog.xaml
@@ -22,6 +22,7 @@
                   Margin="0,8,0,0"
                   HorizontalAlignment="Stretch"
                   PreviewTextInput="OtpTextBox_OnPreviewTextInput"
+                  PreviewKeyDown="OtpTextBox_PreviewKeyDown"
                   KeyDown="OtpTextBox_OnKeyDown"
                   MaxLength="6"
                   Foreground="{DynamicResource MaterialDesignBody}"

--- a/XIVLauncher/Windows/OtpInputDialog.xaml.cs
+++ b/XIVLauncher/Windows/OtpInputDialog.xaml.cs
@@ -60,6 +60,14 @@ namespace XIVLauncher.Windows
             e.Handled = regex.IsMatch(e.Text);
         }
 
+        private void OtpTextBox_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Space)
+            {
+                e.Handled = true;
+            }
+        }
+
         private void OtpTextBox_OnKeyDown(object sender, KeyEventArgs e)
         {
             if ((e.Key != Key.Enter && e.Key != Key.Return) || OtpTextBox.Text.Length != 6) 


### PR DESCRIPTION
PreviewTextInput event doesn't get triggered on Spaces so we have to have this explicit event to handle just spaces. The remainder of the previewtextinput still works as well