### PR TITLE
ADD MahApps.Metro and MaterialDesignThemes.MahApps

### DIFF
--- a/src/XIVLauncher/App.xaml
+++ b/src/XIVLauncher/App.xaml
@@ -1,21 +1,77 @@
 ﻿<Application x:Class="XIVLauncher.App"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              Startup="App_OnStartup">
     <Application.Resources>
         <ResourceDictionary>
             <ResourceDictionary.MergedDictionaries>
+                <!-- MahApps -->
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Controls.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/Styles/Fonts.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MahApps.Metro;component/styles/themes/dark.blue.xaml" />
+                
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/materialdesigncolor.Blue.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Blue.xaml" />
-                
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ComboBox.xaml" />
-
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Dark.xaml" />
+                
+                <!-- Material Design: MahApps Compatibility -->
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Fonts.xaml" />
+                <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.MahApps;component/Themes/MaterialDesignTheme.MahApps.Flyout.xaml" />
 
                 <!-- Include the Dragablz Material Design style -->
-                <ResourceDictionary Source="pack://application:,,,/Dragablz;component/Themes/materialdesign.xaml"/>                
+                <ResourceDictionary Source="pack://application:,,,/Dragablz;component/Themes/materialdesign.xaml"/>
             </ResourceDictionary.MergedDictionaries>
+            
+            
+            <!-- MahApps Brushes -->
+            <SolidColorBrush x:Key="HighlightBrush" Color="{DynamicResource Primary700}"/>
+            <SolidColorBrush x:Key="AccentBaseColorBrush" Color="{DynamicResource Primary600}" />
+            <SolidColorBrush x:Key="AccentColorBrush" Color="{DynamicResource Primary500}"/>
+            <SolidColorBrush x:Key="SecondaryAccentBrush" Color="#0d47a1"/>
+            <SolidColorBrush x:Key="AccentColorBrush2" Color="{DynamicResource Primary400}"/>
+            <SolidColorBrush x:Key="AccentColorBrush3" Color="{DynamicResource Primary300}"/>
+            <SolidColorBrush x:Key="AccentColorBrush4" Color="{DynamicResource Primary200}"/>
+            <SolidColorBrush x:Key="WindowTitleColorBrush" Color="{DynamicResource Primary700}"/>
+            <SolidColorBrush x:Key="AccentSelectedColorBrush" Color="{DynamicResource Primary500Foreground}"/>
+            <LinearGradientBrush x:Key="ProgressBrush" EndPoint="0.001,0.5" StartPoint="1.002,0.5">
+                <GradientStop Color="{DynamicResource Primary700}" Offset="0"/>
+                <GradientStop Color="{DynamicResource Primary300}" Offset="1"/>
+            </LinearGradientBrush>
+            <SolidColorBrush x:Key="CheckmarkFill" Color="{DynamicResource Primary500}"/>
+            <SolidColorBrush x:Key="RightArrowFill" Color="{DynamicResource Primary500}"/>
+            <SolidColorBrush x:Key="IdealForegroundColorBrush" Color="{DynamicResource Primary500Foreground}"/>
+            <SolidColorBrush x:Key="IdealForegroundDisabledBrush" Color="{DynamicResource Primary500}" Opacity="0.4"/>
+            <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchBrush.Win10" Color="{DynamicResource Primary500}" />
+            <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.OnSwitchMouseOverBrush.Win10" Color="{DynamicResource Primary400}" />
+            <SolidColorBrush x:Key="MahApps.Metro.Brushes.ToggleSwitchButton.ThumbIndicatorCheckedBrush.Win10" Color="{DynamicResource Primary500Foreground}" />
+
+            
+            <!--  Window Style  -->
+            <Style
+                x:Key="DalamudWindow"
+                BasedOn="{StaticResource {x:Type mah:MetroWindow}}"
+                TargetType="mah:MetroWindow">
+                <Setter Property="Background" Value="{DynamicResource MaterialDesignPaper}" />
+                <Setter Property="BorderBrush" Value="Black" />
+                <Setter Property="FontFamily" Value="{materialDesign:MaterialDesignFont}" />
+                <Setter Property="Icon" Value="pack://application:,,,/Resources/dalamud_icon.ico" />
+                <Setter Property="NonActiveBorderBrush" Value="Black" />
+                <Setter Property="NonActiveGlowBrush" Value="Black" />
+                <Setter Property="NonActiveWindowTitleBrush" Value="#343434" />
+                <Setter Property="ShowIconOnTitleBar" Value="True" />
+                <Setter Property="TextElement.FontSize" Value="14" />
+                <Setter Property="TextElement.FontWeight" Value="Medium" />
+                <Setter Property="TextElement.Foreground" Value="{DynamicResource MaterialDesignBody}" />
+                <Setter Property="TitleCharacterCasing" Value="Normal" />
+                <Setter Property="TryToBeFlickerFree" Value="True" />
+                <Setter Property="WindowTitleBrush" Value="#343434" />
+                <Setter Property="WindowTransitionsEnabled" Value="True" />
+            </Style>
+            
         </ResourceDictionary>
     </Application.Resources>
 

--- a/src/XIVLauncher/Settings/ILauncherSettingsV3.cs
+++ b/src/XIVLauncher/Settings/ILauncherSettingsV3.cs
@@ -31,7 +31,7 @@ namespace XIVLauncher.Settings
         DirectoryInfo PatchPath { get; set; }
         bool? AskBeforePatchInstall { get; set; } 
         long SpeedLimitBytes { get; set; } 
-        decimal DalamudInjectionDelayMs { get; set; }
+        double DalamudInjectionDelayMs { get; set; }
         bool? KeepPatches { get; set; }
         bool? OptOutMbCollection { get; set; }
         bool? HasComplainedAboutAdmin { get; set; }

--- a/src/XIVLauncher/Windows/ChangelogWindow.xaml
+++ b/src/XIVLauncher/Windows/ChangelogWindow.xaml
@@ -1,17 +1,15 @@
-﻿<Window
+﻿<mah:MetroWindow
     x:Class="XIVLauncher.Windows.ChangelogWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
     mc:Ignorable="d"
+    Style="{DynamicResource DalamudWindow}"
     Title="XIVLauncher Update" Height="Auto" MaxWidth="640" WindowStartupLocation="CenterScreen"
-    Icon="pack://application:,,,/Resources/dalamud_icon.ico" ResizeMode="NoResize" SizeToContent="WidthAndHeight"
-    TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-    Background="{DynamicResource MaterialDesignPaper}"
-    TextElement.FontWeight="Medium"
-    FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto">
+    ResizeMode="NoResize" SizeToContent="WidthAndHeight">
     <StackPanel>
         <StackPanel>
             <TextBlock
@@ -55,4 +53,4 @@
             <Button Margin="0,0,0,0" HorizontalAlignment="Right" Click="CloseButton_Click" Content="{Binding OkLoc}"/>
         </StackPanel>
     </StackPanel>
-</Window>
+</mah:MetroWindow>

--- a/src/XIVLauncher/Windows/ChangelogWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/ChangelogWindow.xaml.cs
@@ -13,7 +13,7 @@ namespace XIVLauncher.Windows
     /// <summary>
     /// Interaction logic for ErrorWindow.xaml
     /// </summary>
-    public partial class ChangelogWindow : Window
+    public partial class ChangelogWindow
     {
         public ChangelogWindow()
         {

--- a/src/XIVLauncher/Windows/CustomMessageBox.xaml
+++ b/src/XIVLauncher/Windows/CustomMessageBox.xaml
@@ -1,17 +1,15 @@
-﻿<Window
+﻿<mah:MetroWindow
     x:Class="XIVLauncher.Windows.CustomMessageBox"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+    xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
     mc:Ignorable="d"
+    Style="{DynamicResource DalamudWindow}"
     Title="XIVLauncher Error" Height="Auto" Width="Auto" WindowStartupLocation="CenterScreen"
-    Icon="pack://application:,,,/Resources/dalamud_icon.ico" ResizeMode="NoResize"
-    TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-    Background="{DynamicResource MaterialDesignPaper}"
-    TextElement.FontWeight="Medium"
-    FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto"
+    ResizeMode="NoResize"
     SizeToContent="WidthAndHeight">
     <Grid>
         <StackPanel
@@ -40,4 +38,4 @@
             <Button Margin="0,0,0,0" HorizontalAlignment="Right" Click="CloseButton_Click" Content="{Binding OkLoc}" />
         </StackPanel>
     </Grid>
-</Window>
+</mah:MetroWindow>

--- a/src/XIVLauncher/Windows/CustomMessageBox.xaml.cs
+++ b/src/XIVLauncher/Windows/CustomMessageBox.xaml.cs
@@ -14,7 +14,7 @@ namespace XIVLauncher.Windows
     /// <summary>
     /// Interaction logic for ErrorWindow.xaml
     /// </summary>
-    public partial class CustomMessageBox : Window
+    public partial class CustomMessageBox
     {
         public static App InvokableApp { get; set; } 
 

--- a/src/XIVLauncher/Windows/ErrorWindow.xaml
+++ b/src/XIVLauncher/Windows/ErrorWindow.xaml
@@ -1,17 +1,15 @@
-﻿<Window
+﻿<mah:MetroWindow
   x:Class="XIVLauncher.Windows.ErrorWindow"
   xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
   xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
   xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+  xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
   mc:Ignorable="d"
+  Style="{DynamicResource DalamudWindow}"
   Title="XIVLauncher Error" Height="295" Width="598" WindowStartupLocation="CenterScreen"
-  Icon="pack://application:,,,/Resources/dalamud_icon.ico" ResizeMode="NoResize"
-  TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-  Background="{DynamicResource MaterialDesignPaper}"
-  TextElement.FontWeight="Medium"
-  FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto">
+  ResizeMode="NoResize">
   <Grid>
     <StackPanel>
       <TextBlock
@@ -56,11 +54,11 @@
       <Button Style="{DynamicResource MaterialDesignFlatButton}" HorizontalAlignment="Left"
                     x:Name="GitHubButton" Margin="0,0,5,0" Click="GitHubButton_OnClick">
         <StackPanel Orientation="Horizontal">
-          <materialDesign:PackIcon Kind="GithubCircle" />
+          <materialDesign:PackIcon Kind="Github" />
                     <TextBlock Margin="8 0 0 0" VerticalAlignment="Center" Text="{Binding ReportErrorLoc}"/>
         </StackPanel>
       </Button>
             <Button Margin="0,0,0,0" HorizontalAlignment="Right" Click="CloseButton_Click" Content="{Binding OkLoc}"/>
     </StackPanel>
   </Grid>
-</Window>
+</mah:MetroWindow>

--- a/src/XIVLauncher/Windows/ErrorWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/ErrorWindow.xaml.cs
@@ -11,7 +11,7 @@ namespace XIVLauncher.Windows
     /// <summary>
     /// Interaction logic for ErrorWindow.xaml
     /// </summary>
-    public partial class ErrorWindow : Window
+    public partial class ErrorWindow
     {
         public ErrorWindow(Exception exc, string message, string context)
         {

--- a/src/XIVLauncher/Windows/FirstTimeSetupWindow.xaml
+++ b/src/XIVLauncher/Windows/FirstTimeSetupWindow.xaml
@@ -1,17 +1,17 @@
-﻿<Window x:Class="XIVLauncher.Windows.FirstTimeSetup"
+﻿<mah:MetroWindow x:Class="XIVLauncher.Windows.FirstTimeSetup"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:XIVLauncher"
         xmlns:components="clr-namespace:XIVLauncher.Xaml.Components"
+        xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
+        Style="{DynamicResource DalamudWindow}"
         mc:Ignorable="d"
-        Title="XIVLauncher Setup" SizeToContent="Height" Width="450" WindowStartupLocation="CenterScreen"
-        Icon="pack://application:,,,/Resources/dalamud_icon.ico" ResizeMode="NoResize"
-        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-        Background="{DynamicResource MaterialDesignPaper}"
-        TextElement.FontWeight="Medium"
-        FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto">
+        Title="XIVLauncher Setup"
+        SizeToContent="Height"
+        Width="450"
+        WindowStartupLocation="CenterScreen">
     <Grid>
         <TabControl IsEnabled="True" BorderThickness="0" x:Name="SetupTabControl"
                     Background="{DynamicResource MaterialDesignPaper}">
@@ -115,4 +115,4 @@
             </TabItem>
         </TabControl>
     </Grid>
-</Window>
+</mah:MetroWindow>

--- a/src/XIVLauncher/Windows/FirstTimeSetupWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/FirstTimeSetupWindow.xaml.cs
@@ -14,7 +14,7 @@ namespace XIVLauncher.Windows
     /// <summary>
     ///     Interaction logic for FirstTimeSetup.xaml
     /// </summary>
-    public partial class FirstTimeSetup : Window
+    public partial class FirstTimeSetup 
     {
         public bool WasCompleted { get; private set; } = false;
 

--- a/src/XIVLauncher/Windows/GenericAddonSetupWindow.xaml
+++ b/src/XIVLauncher/Windows/GenericAddonSetupWindow.xaml
@@ -1,20 +1,20 @@
-﻿<Window x:Class="XIVLauncher.Windows.GenericAddonSetupWindow"
+﻿<mah:MetroWindow x:Class="XIVLauncher.Windows.GenericAddonSetupWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:local="clr-namespace:XIVLauncher"
         xmlns:components="clr-namespace:XIVLauncher.Xaml.Components"
+        xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
         mc:Ignorable="d"
+        ResizeMode="NoResize"
+        Style="{DynamicResource DalamudWindow}"
         Title="{Binding GenericAddonSetupTitleLoc}" Height="281.747" Width="533.495"
-        WindowStartupLocation="CenterScreen"
-        Icon="pack://application:,,,/Resources/dalamud_icon.ico" ResizeMode="NoResize"
-        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-        Background="{DynamicResource MaterialDesignPaper}"
-        TextElement.FontWeight="Medium"
-        FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto">
+        WindowStartupLocation="CenterScreen">
     <Grid>
-        <TextBlock HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,10,0,0"
+        <TextBlock HorizontalAlignment="Left"
+                   TextWrapping="Wrap"
+                   VerticalAlignment="Top" Margin="10,10,0,0"
                    Text="{Binding GenericAddonSetupDescriptionLoc}" />
         <components:FileEntry x:Name="PathEntry" Description="Select an Addon file"
                               Filters="EXE File, *.exe;Powershell Script, *.ps1;Shell Script, *.bat" Margin="10,0,0,80"
@@ -32,4 +32,4 @@
         <Button Content="{Binding OkLoc}" Width="79" VerticalAlignment="Bottom" HorizontalAlignment="Right"
                 Margin="0,0,10,10" Click="NextButton_Click" />
     </Grid>
-</Window>
+</mah:MetroWindow>

--- a/src/XIVLauncher/Windows/GenericAddonSetupWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/GenericAddonSetupWindow.xaml.cs
@@ -7,7 +7,7 @@ namespace XIVLauncher.Windows
     /// <summary>
     ///     Interaction logic for FirstTimeSetup.xaml
     /// </summary>
-    public partial class GenericAddonSetupWindow : Window
+    public partial class GenericAddonSetupWindow
     {
         public GenericAddon Result { get; private set; }
 

--- a/src/XIVLauncher/Windows/IntegrityCheckProgressWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/IntegrityCheckProgressWindow.xaml.cs
@@ -7,7 +7,7 @@ namespace XIVLauncher.Windows
     /// <summary>
     ///     Interaction logic for FirstTimeSetup.xaml
     /// </summary>
-    public partial class IntegrityCheckProgressWindow : Window
+    public partial class IntegrityCheckProgressWindow
     {
         public IntegrityCheckProgressWindow()
         {

--- a/src/XIVLauncher/Windows/MainWindow.xaml
+++ b/src/XIVLauncher/Windows/MainWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window
+﻿<mah:MetroWindow
     x:Class="XIVLauncher.Windows.MainWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -9,16 +9,13 @@
     xmlns:system="clr-namespace:System;assembly=mscorlib"
     xmlns:game="clr-namespace:XIVLauncher.Game"
     xmlns:windows="clr-namespace:XIVLauncher.Windows"
+    xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
     mc:Ignorable="d"
     Title="XIVLauncher"
     Width="845"
     Height="376"
+    Style="{DynamicResource DalamudWindow}"
     ResizeMode="CanMinimize" WindowStartupLocation="CenterScreen"
-    Icon="pack://application:,,,/Resources/dalamud_icon.ico"
-    TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-    Background="{DynamicResource MaterialDesignPaper}"
-    TextElement.FontWeight="Medium"
-    FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto"
     Closed="MainWindow_OnClosed">
 
     <Window.Resources>
@@ -274,4 +271,4 @@
             </materialDesign:TransitionerSlide>
         </materialDesign:Transitioner>
     </Grid>
-</Window>
+</mah:MetroWindow>

--- a/src/XIVLauncher/Windows/MainWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/MainWindow.xaml.cs
@@ -31,7 +31,7 @@ namespace XIVLauncher.Windows
     /// <summary>
     ///     Interaction logic for MainWindow.xaml
     /// </summary>
-    public partial class MainWindow : Window
+    public partial class MainWindow
     {
         private Timer _bannerChangeTimer;
         private Headlines _headlines;

--- a/src/XIVLauncher/Windows/ProfilePictureInputWindow.xaml
+++ b/src/XIVLauncher/Windows/ProfilePictureInputWindow.xaml
@@ -1,30 +1,29 @@
-﻿<Window x:Class="XIVLauncher.Windows.ProfilePictureInputWindow"
+﻿<mah:MetroWindow x:Class="XIVLauncher.Windows.ProfilePictureInputWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
         xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
-        xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+        Style="{DynamicResource DalamudWindow}"
+        xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
         mc:Ignorable="d"
-        Title="{Binding ProfilePictureInputTitleLoc}" Height="268.361" Width="535.302" WindowStartupLocation="CenterScreen"
-        Icon="pack://application:,,,/Resources/dalamud_icon.ico" ResizeMode="NoResize"
-        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
-        Background="{DynamicResource MaterialDesignPaper}"
-        TextElement.FontWeight="Medium"
-        FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto">
-    <StackPanel>
-        <TextBlock HorizontalAlignment="Left" VerticalAlignment="Top" Margin="10,10,0,0" Text="{Binding ProfilePictureInputDescriptionLoc}"/>
+        Title="{Binding ProfilePictureInputTitleLoc}"
+        Height="268.361" Width="535.302" 
+        WindowStartupLocation="CenterScreen"
+        ResizeMode="NoResize">
+    <StackPanel Margin="10">
+        <TextBlock HorizontalAlignment="Left" VerticalAlignment="Top" Margin="0,0,0,0" Text="{Binding ProfilePictureInputDescriptionLoc}"/>
 
-        <StackPanel Orientation="Vertical" Width="180" HorizontalAlignment="Left" Margin="10,20,0,0">
+        <StackPanel Orientation="Vertical" Width="180" HorizontalAlignment="Left" Margin="0,20,0,0">
             <Label Width="210" VerticalAlignment="Center" HorizontalAlignment="Left" Content="{Binding CharacterNameLoc}"/>
             <TextBox x:Name="CharacterNameTextBox" Width="203"/>
         </StackPanel>
 
-        <StackPanel Orientation="Vertical" Width="180" HorizontalAlignment="Left" Margin="10,10,0,0">
+        <StackPanel Orientation="Vertical" Width="180" HorizontalAlignment="Left" Margin="0,10,0,0">
             <Label Width="210" VerticalAlignment="Center" HorizontalAlignment="Left" Content="{Binding WorldNameLoc}"/>
             <TextBox x:Name="WorldNameTextBox" Width="203"/>
         </StackPanel>
 
-        <Button Content="{Binding OkLoc}" Width="79" VerticalAlignment="Bottom" HorizontalAlignment="Right" Click="NextButton_Click" Margin="220,50,0,0"/>
+        <Button Content="{Binding OkLoc}" Width="79" VerticalAlignment="Bottom" HorizontalAlignment="Right" Click="NextButton_Click" Margin="220,26,0,0"/>
     </StackPanel>
-</Window>
+</mah:MetroWindow>

--- a/src/XIVLauncher/Windows/ProfilePictureInputWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/ProfilePictureInputWindow.xaml.cs
@@ -7,7 +7,7 @@ namespace XIVLauncher.Windows
     /// <summary>
     /// Interaction logic for FirstTimeSetup.xaml
     /// </summary>
-    public partial class ProfilePictureInputWindow : Window
+    public partial class ProfilePictureInputWindow
     {
         public string ResultName, ResultWorld;
 

--- a/src/XIVLauncher/Windows/SettingsControl.xaml
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml
@@ -10,6 +10,7 @@
              xmlns:components="clr-namespace:XIVLauncher.Xaml.Components"
              xmlns:viewModel="clr-namespace:XIVLauncher.Windows.ViewModel"
              xmlns:xctk="http://schemas.xceed.com/wpf/xaml/toolkit"
+             xmlns:mah="http://metro.mahapps.com/winfx/xaml/controls"
              mc:Ignorable="d"
              TextElement.Foreground="{DynamicResource MaterialDesignBody}"
              Background="{DynamicResource MaterialDesignPaper}"
@@ -21,7 +22,8 @@
     </UserControl.Resources>
     <Grid>
         <dragablz:TabablzControl IsEnabled="True" FixedHeaderCount="7" x:Name="SetupTabControl"
-                                 Style="{StaticResource MaterialDesignTabablzControlStyle}">
+                                 BorderThickness="0"
+                                 Style="{DynamicResource MaterialDesignTabablzControlStyle}">
             <TabItem Header="{Binding SettingsGameLoc}">
                 <StackPanel Margin="10,10,0,0">
                     <TextBlock HorizontalAlignment="Left" VerticalAlignment="Top"
@@ -161,7 +163,7 @@
                                        Content="{Binding InGameAddonInjectionDelayLoc}" />
 
                                 <StackPanel Orientation="Horizontal">
-                                    <xctk:DecimalUpDown x:Name="InjectionDelayUpDown" Margin="10,0,0,10" Width="60" HorizontalAlignment="Left" Value="0"/>
+                                    <mah:NumericUpDown Minimum="0" x:Name="InjectionDelayUpDown" Margin="10,0,0,10" Width="150" HorizontalAlignment="Left" Value="0"/>
                                     <Label Foreground="{DynamicResource MaterialDesignBody}" Margin="0,0,0,0"
                                            Content="ms" ToolTip="{Binding InGameAddonInjectionDelayDescriptionLoc}"/>
                                 </StackPanel>
@@ -221,7 +223,7 @@
                            Content="{Binding PatchSpeedLimitLoc}" />
 
                     <StackPanel Orientation="Horizontal">
-                        <xctk:DecimalUpDown x:Name="SpeedLimiterUpDown" Margin="10,0,0,0" Width="60" HorizontalAlignment="Left" Value="0"/>
+                        <mah:NumericUpDown Minimum="0" MinWidth="150" x:Name="SpeedLimiterUpDown" Margin="10,0,0,0" Width="60" HorizontalAlignment="Left" Value="0"/>
                         <Label Foreground="{DynamicResource MaterialDesignBody}" Margin="0,0,0,0"
                                Content="MB/s" />
                     </StackPanel>
@@ -268,7 +270,7 @@
                                     HorizontalAlignment="Left"
                                     x:Name="GitHubButton" Click="GitHubButton_OnClick" Margin="0 0 0 0">
                                 <StackPanel Orientation="Horizontal">
-                                    <materialDesign:PackIcon Kind="GithubCircle" />
+                                    <materialDesign:PackIcon Kind="Github" />
                                     <TextBlock Margin="8 0 0 0" VerticalAlignment="Center">GitHub</TextBlock>
                                 </StackPanel>
                             </Button>

--- a/src/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -88,7 +88,7 @@ namespace XIVLauncher.Windows
 
             VersionLabel.Text += " - v" + Util.GetAssemblyVersion() + " - " + Util.GetGitHash() + " - " + Environment.Version;
 
-            var val = (decimal) App.Settings.SpeedLimitBytes / BYTES_TO_MB;
+            var val = (double) App.Settings.SpeedLimitBytes / BYTES_TO_MB;
 
             SpeedLimiterUpDown.Value = val;
         }

--- a/src/XIVLauncher/XIVLauncher.csproj
+++ b/src/XIVLauncher/XIVLauncher.csproj
@@ -87,7 +87,9 @@
     <PackageReference Include="Downloader" Version="2.2.8" />
     <PackageReference Include="Dragablz" Version="0.0.3.203" />
     <PackageReference Include="Extended.Wpf.Toolkit" Version="3.5.0" />
-    <PackageReference Include="MaterialDesignThemes" Version="2.5.1" />
+    <PackageReference Include="MahApps.Metro" Version="2.4.7" />
+    <PackageReference Include="MaterialDesignThemes" Version="4.1.0" />
+    <PackageReference Include="MaterialDesignThemes.MahApps" Version="0.1.7" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.WindowsAPICodePack-Shell" Version="1.1.0" />
     <PackageReference Include="MonoTorrent" Version="2.0.0" />


### PR DESCRIPTION
UPDATE MaterialDesignThemes to latest version

to get rid of the ugly white titlebar i added MahApps and updated every window xaml file with titlebar enabled to use the new MetroWindow from MahApps

in App.xaml i added a default window style named 'DalamudWindow' which every MetroWindow is using

i also changed DalamudInjectionDelayMs from decimal to double in ILauncherSettingsV3 for the new NumericUpDown control from MahApps replacing DecimalUpDown since the old one was ugly and unstyled