### PR TITLE
Move integrity to appdata\roaming

### DIFF
--- a/src/XIVLauncher/App.xaml.cs
+++ b/src/XIVLauncher/App.xaml.cs
@@ -221,7 +221,11 @@ namespace XIVLauncher
                     if (arg == "--genIntegrity")
                     {
                         var result = IntegrityCheck.RunIntegrityCheckAsync(Settings.GamePath, null).GetAwaiter().GetResult();
-                        File.WriteAllText($"{result.GameVersion}.json", JsonConvert.SerializeObject(result));
+                        string saveIntegrityPath = Path.Combine(Paths.RoamingPath, $"{result.GameVersion}.json");
+#if DEBUG
+                        Log.Information("Saving integrity to " + saveIntegrityPath);
+#endif
+                        File.WriteAllText(saveIntegrityPath, JsonConvert.SerializeObject(result));
 
                         MessageBox.Show($"Successfully hashed {result.Hashes.Count} files.");
                         Environment.Exit(0);

--- a/src/XIVLauncher/Resources/Loc/XIVLauncher_Localizable.json
+++ b/src/XIVLauncher/Resources/Loc/XIVLauncher_Localizable.json
@@ -203,6 +203,10 @@
     "message": "An error in XIVLauncher occured. Please consult the FAQ. If this issue persists, please report\r\nit on GitHub by clicking the button below, describing the issue and copying the text in the box.",
     "description": "ErrorWindowViewModel.SetupLoc"
   },
+  "OpenIntegrityReport": {
+    "message": "Open Integrity Report",
+    "description": "ErrorWindowViewModel.SetupLoc"
+  },
   "OpenFaq": {
     "message": "Open FAQ",
     "description": "ErrorWindowViewModel.SetupLoc"

--- a/src/XIVLauncher/Windows/CustomMessageBox.xaml
+++ b/src/XIVLauncher/Windows/CustomMessageBox.xaml
@@ -27,17 +27,24 @@
                     x:Name="DiscordButton" Margin="0,0,5,0">
                 <StackPanel Orientation="Horizontal">
                     <materialDesign:PackIcon Kind="Discord" />
-                    <TextBlock Margin="8 0 0 0" VerticalAlignment="Center" Text="{Binding JoinDiscordLoc}" />
+                    <TextBlock Margin="8 0 0 0" VerticalAlignment="Center" Text="{Binding JoinDiscordLoc}"/>
                 </StackPanel>
             </Button>
             <Button Style="{DynamicResource MaterialDesignFlatButton}" HorizontalAlignment="Left"
                     x:Name="FaqButton" Margin="0,0,5,0" Click="FaqButton_OnClick">
                 <StackPanel Orientation="Horizontal">
-                    <materialDesign:PackIcon Kind="Information" />
-                    <TextBlock Margin="8 0 0 0" VerticalAlignment="Center" Text="{Binding OpenFaqLoc}" />
+                    <materialDesign:PackIcon  Kind="Information" />
+                    <TextBlock Margin="8 0 0 0" VerticalAlignment="Center" Text="{Binding OpenFaqLoc}"/>
                 </StackPanel>
             </Button>
-            <Button Margin="0,0,0,0" HorizontalAlignment="Right" Click="CloseButton_Click" Content="{Binding OkLoc}" />
+            <Button Style="{DynamicResource MaterialDesignFlatButton}" HorizontalAlignment="Left"
+                    x:Name="IntegrityReportButton" Margin="0,0,5,0" Click="IntegrityReportButton_OnClick">
+                <StackPanel Orientation="Horizontal">
+                    <materialDesign:PackIcon Kind="FileDocument" />
+                    <TextBlock Margin="8 0 0 0" VerticalAlignment="Center" Text="{Binding OpenIntegrityReportLoc}"/>
+                </StackPanel>
+            </Button>
+            <Button Margin="0,0,0,0" HorizontalAlignment="Right" Click="CloseButton_Click" Content="{Binding OkLoc}"/>
         </StackPanel>
     </Grid>
 </Window>

--- a/src/XIVLauncher/Windows/CustomMessageBox.xaml.cs
+++ b/src/XIVLauncher/Windows/CustomMessageBox.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.IO;
 using System.Media;
 using System.Threading;
 using System.Windows;
@@ -31,7 +32,7 @@ namespace XIVLauncher.Windows
             Focus();
         }
 
-        public static void Show(string text, string caption, MessageBoxButton buttons = MessageBoxButton.OK, MessageBoxImage image = MessageBoxImage.Asterisk, bool showHelpLinks = true)
+        public static void Show(string text, string caption, MessageBoxButton buttons = MessageBoxButton.OK, MessageBoxImage image = MessageBoxImage.Asterisk, bool showHelpLinks = true, bool showReportLinks = false)
         {
             var signal = new ManualResetEvent(false);
 
@@ -83,6 +84,15 @@ namespace XIVLauncher.Windows
                     box.FaqButton.Visibility = Visibility.Visible;
                 }
 
+                if(!showReportLinks)
+                {
+                    box.IntegrityReportButton.Visibility = Visibility.Collapsed;
+                }
+                else
+                {
+                    box.IntegrityReportButton.Visibility = Visibility.Visible;
+                }
+
                 box.ShowDialog();
 
                 signal.Set();
@@ -100,5 +110,11 @@ namespace XIVLauncher.Windows
         {
             Process.Start("https://goatcorp.github.io/faq/");
         }
+
+         private void IntegrityReportButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            Process.Start(Path.Combine(Paths.RoamingPath, "integrityreport.txt"));
+        }
+
     }
 }

--- a/src/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -233,6 +233,12 @@ namespace XIVLauncher.Windows
             {
                 window.Dispatcher.Invoke(() => window.Close());
 
+                string saveIntegrityPath = Path.Combine(Paths.RoamingPath, "integrityreport.txt");
+#if DEBUG
+                Log.Information("Saving integrity to " + saveIntegrityPath);
+#endif
+                File.WriteAllText(saveIntegrityPath, task.Result.report);
+
                 switch (task.Result.compareResult)
                 {
                     case IntegrityCheck.CompareResult.NoServer:
@@ -242,18 +248,10 @@ namespace XIVLauncher.Windows
                         return;
 
                     case IntegrityCheck.CompareResult.Invalid:
-                    {
-                            string saveIntegrityPath = Path.Combine(Paths.RoamingPath, "integrityreport.txt");
-#if DEBUG
-                            Log.Information("Saving integrity to " + saveIntegrityPath);
-#endif
-                        File.WriteAllText(saveIntegrityPath, task.Result.report);
                         CustomMessageBox.Show(Loc.Localize("IntegrityCheckFailed",
-                                "Some game files seem to be modified or corrupted. Please check the \"integrityreport.txt\" file in the XIVLauncher folder for more information.\n\nIf you use TexTools mods, this is an expected result.\n\nIf you do not use mods, please reinstall your game."),
-                            "XIVLauncher", MessageBoxButton.OK, MessageBoxImage.Exclamation);
-
-                        break;
-                    }
+                            "Some game files seem to be modified or corrupted. Please check the \"integrityreport.txt\" file in the XIVLauncher folder for more information.\n\nIf you use TexTools mods, this is an expected result.\n\nIf you do not use mods, please reinstall your game."),
+                        "XIVLauncher", MessageBoxButton.OK, MessageBoxImage.Exclamation);
+                    break;
 
                     case IntegrityCheck.CompareResult.Valid:
                         CustomMessageBox.Show(Loc.Localize("IntegrityCheckValid", "Your game install seems to be valid."), "XIVLauncher", MessageBoxButton.OK,

--- a/src/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -243,7 +243,11 @@ namespace XIVLauncher.Windows
 
                     case IntegrityCheck.CompareResult.Invalid:
                     {
-                        File.WriteAllText("integrityreport.txt", task.Result.report);
+                            string saveIntegrityPath = Path.Combine(Paths.RoamingPath, "integrityreport.txt");
+#if DEBUG
+                            Log.Information("Saving integrity to " + saveIntegrityPath);
+#endif
+                        File.WriteAllText(saveIntegrityPath, task.Result.report);
                         CustomMessageBox.Show(Loc.Localize("IntegrityCheckFailed",
                                 "Some game files seem to be modified or corrupted. Please check the \"integrityreport.txt\" file in the XIVLauncher folder for more information.\n\nIf you use TexTools mods, this is an expected result.\n\nIf you do not use mods, please reinstall your game."),
                             "XIVLauncher", MessageBoxButton.OK, MessageBoxImage.Exclamation);

--- a/src/XIVLauncher/Windows/ViewModel/ErrorWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/ErrorWindowViewModel.cs
@@ -19,6 +19,7 @@ namespace XIVLauncher.Windows.ViewModel
             ErrorExplanationMsgLoc = Loc.Localize("ErrorExplanation",
                 "An error in XIVLauncher occured. Please consult the FAQ. If this issue persists, please report\r\nit on GitHub by clicking the button below, describing the issue and copying the text in the box.");
             JoinDiscordLoc = Loc.Localize("JoinDiscord", "Join Discord");
+            OpenIntegrityReportLoc = Loc.Localize("OpenIntegrityReport", "Open Integrity Report");
             OpenFaqLoc = Loc.Localize("OpenFaq", "Open FAQ");
             ReportErrorLoc = Loc.Localize("ReportError", "Report error");
             OkLoc = Loc.Localize("OK", "OK");
@@ -26,6 +27,7 @@ namespace XIVLauncher.Windows.ViewModel
 
         public string ErrorExplanationMsgLoc { get; private set; }
         public string JoinDiscordLoc { get; private set; }
+        public string OpenIntegrityReportLoc { get; private set; }
         public string OpenFaqLoc { get; private set; }
         public string ReportErrorLoc { get; private set; }
         public string OkLoc { get; private set; }


### PR DESCRIPTION
- Moves integrity json and report to `%appdata%\xivlauncher`
- Bolt on a button to open the integrity report