### PR TITLE
GenericAddon process wasn't closed after the game closed.

### DIFF
--- a/src/XIVLauncher/Addon/Implementations/GenericAddon.cs
+++ b/src/XIVLauncher/Addon/Implementations/GenericAddon.cs
@@ -75,7 +75,12 @@ namespace XIVLauncher.Addon
                         return;
 
                     if (!_addonProcess.HasExited && KillAfterClose)
+                    {
+                        if (!_addonProcess.CloseMainWindow() || !_addonProcess.WaitForExit(1000))
+                            _addonProcess.Kill();
+
                         _addonProcess.Close();
+                    }
                 }
                 catch(Exception ex)
                 {


### PR DESCRIPTION
The used `Process.Close()` doesn't really terminate the process, it just frees the recourses you hold on the process. To terminate a process a message must be send to notify the process to close or the process needs to be killed.
So I tried to terminate the process gently by closing the Main window and if this doesn't do the trick after one second only then the process is killed.