### PR TITLE
fix: clean HTTP response, add version info inside

### DIFF
--- a/src/XIVLauncher/Http/HttpServer.cs
+++ b/src/XIVLauncher/Http/HttpServer.cs
@@ -13,7 +13,18 @@ namespace XIVLauncher.Http
     public class HttpServer
     {
         private TcpListener _listener;
-        private readonly byte[] httpResponse = Encoding.Default.GetBytes("HTTP/1.0 200 OK\n\nContent-Type: text/plain; charset=UTF-8\r\n\r\n");
+        private readonly byte[] httpResponse = Encoding.Default.GetBytes(
+            "HTTP/1.0 200 OK\n"+
+            "Content-Type: application/json; charset=UTF-8\n"+
+            "\n"+
+            "{app:\"XIVLauncher\", version: \"" +
+#if !XL_NOAUTOUPDATE
+            Util.GetAssemblyVersion() +
+#else
+            Util.GetGitHash() +
+#endif
+            "\"}"
+        );
 
         public EventHandler<HttpServerGetEvent> GetReceived;
 


### PR DESCRIPTION
Hey, 

I was about to build a script to auto send my OTP to the launcher, but it felt weird sending this code without checking who's receiving it so I digged into the launcher code.

## Fix the HTTP response format
I removed some double newlines causing headers to be sent as body

## Add a JSON response with version info
I added the appname and version name in the response, to be able to check if we're in fact talking to XIVLauncher

Thanks for the launcher, it's great !

Bests,
Pof