### PR TITLE
Change Dalamud launcher to run code on entry point instead of late DLL injection

### DIFF
--- a/src/XIVLauncher/Game/Launcher.cs
+++ b/src/XIVLauncher/Game/Launcher.cs
@@ -140,7 +140,7 @@ namespace XIVLauncher.Game
         }
 
         public static Process LaunchGame(string sessionId, int region, int expansionLevel, bool isSteamIntegrationEnabled, bool isSteamServiceAccount, string additionalArguments, DirectoryInfo gamePath, bool isDx11, ClientLanguage language,
-            bool encryptArguments)
+            bool encryptArguments, Action<Process> beforeResume)
         {
             Log.Information($"XivGame::LaunchGame(steamIntegration:{isSteamIntegrationEnabled}, steamServiceAccount:{isSteamServiceAccount}, args:{additionalArguments})");
 
@@ -209,7 +209,7 @@ namespace XIVLauncher.Game
                     var arguments = encryptArguments
                         ? argumentBuilder.BuildEncrypted()
                         : argumentBuilder.Build();
-                    game = NativeAclFix.LaunchGame(workingDir, exePath, arguments, environment);
+                    game = NativeAclFix.LaunchGame(workingDir, exePath, arguments, environment, beforeResume);
                 }
                 catch (Win32Exception ex)
                 {

--- a/src/XIVLauncher/Game/NativeAclFix.cs
+++ b/src/XIVLauncher/Game/NativeAclFix.cs
@@ -318,7 +318,7 @@ namespace XIVLauncher.Game
             }
         }
 
-        public static Process LaunchGame(string workingDir, string exePath, string arguments, IDictionary<string, string> envVars)
+        public static Process LaunchGame(string workingDir, string exePath, string arguments, IDictionary<string, string> envVars, Action<Process> beforeResume)
         {
             Process process;
 
@@ -393,6 +393,9 @@ namespace XIVLauncher.Game
                 DisableSeDebug(lpProcessInformation.hProcess);
 
                 process = new ExistingProcess(lpProcessInformation.hProcess);
+
+                beforeResume?.Invoke(process);
+
                 PInvoke.ResumeThread(lpProcessInformation.hThread);
 
                 process.WaitForInputIdle();

--- a/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
@@ -393,7 +393,19 @@ namespace XIVLauncher.Windows.ViewModel
 
             var gameProcess = Launcher.LaunchGame(loginResult.UniqueId, loginResult.OauthLogin.Region,
                     loginResult.OauthLogin.MaxExpansion, App.Settings.SteamIntegrationEnabled,
-                    isSteam, App.Settings.AdditionalLaunchArgs, App.Settings.GamePath, App.Settings.IsDx11, App.Settings.Language.GetValueOrDefault(ClientLanguage.English), App.Settings.EncryptArguments.GetValueOrDefault(false));
+                    isSteam, App.Settings.AdditionalLaunchArgs, App.Settings.GamePath, App.Settings.IsDx11, App.Settings.Language.GetValueOrDefault(ClientLanguage.English), App.Settings.EncryptArguments.GetValueOrDefault(false),
+                    process => {
+                        if (App.Settings.InGameAddonEnabled && App.Settings.IsDx11)
+                        {
+                            var launcher = new DalamudLauncher(DalamudUpdater.Overlay);
+                            launcher.Setup(process, App.Settings);
+                            launcher.Run();
+                        }
+                        else
+                        {
+                            Log.Warning("In-Game addon was not enabled.");
+                        }
+                    });
 
             if (gameProcess == null)
             {
@@ -414,16 +426,6 @@ namespace XIVLauncher.Windows.ViewModel
                     App.Settings.AddonList = new List<AddonEntry>();
 
                 var addons = App.Settings.AddonList.Where(x => x.IsEnabled).Select(x => x.Addon).Cast<IAddon>().ToList();
-
-                if (App.Settings.InGameAddonEnabled && App.Settings.IsDx11)
-                {
-                    addons.Add(new DalamudLauncher(DalamudUpdater.Overlay));
-                }
-                else
-                {
-                    Log.Warning("In-Game addon was not enabled.");
-                }
-
                 addonMgr.RunAddons(gameProcess, App.Settings, addons);
             }
             catch (Exception ex)


### PR DESCRIPTION
This PR needs to be managed with [Dalamud#681](https://github.com/goatcorp/Dalamud/pull/681).

* This method of loading Dalamud should reduce the number of problems caused from false positive detection, as a lot of antiviruses trip on (1) `WriteProcessMemory` to a process handle obtained via `OpenProcess` and (2) `CreateRemoteThread`.

## Things to consider
* `App.Settings.DalamudInjectionDelayMs` will have to be repurposed for something else.
    * Do `Sleep` before calling `Initialize` from `RewrittenEntryPoint`? This will introduce an additional dependency of [nlohmann/json](https://github.com/nlohmann/json).
* Do we just replace the method of loading Dalamud from injection to entry point modification, or should that remain as a troubleshooting option?
* `SetDllDirectory` will be called before `RewriteRemoteEntryPoint` (global solution for local requirement), because I'm not sure about the best way to do `DllImport` from a variable absolute path. Is there a better way?
* Should `IEntryPointAddon` be added? Neither of `IRunnableAddon` nor `IPersistentAddon` fits the use case for this one. Should it