### PR TITLE
Default Wine users to use DLL Injection method

### DIFF
--- a/src/XIVLauncher/Windows/MainWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/MainWindow.xaml.cs
@@ -207,6 +207,10 @@ namespace XIVLauncher.Windows
             App.Settings.PatchAcquisitionMethod ??=
                 EnvironmentSettings.IsWine ? AcquisitionMethod.NetDownloader : AcquisitionMethod.Aria;
 
+            // Set the default Dalamud launcher method
+            App.Settings.InGameAddonLoadMethod =
+                EnvironmentSettings.IsWine ? DalamudLoadMethod.DllInject : DalamudLoadMethod.EntryPoint;
+
             // Clean up invalid addons
             if (App.Settings.AddonList != null)
                 App.Settings.AddonList = App.Settings.AddonList.Where(x => !string.IsNullOrEmpty(x.Addon.Path)).ToList();


### PR DESCRIPTION
Wine/CrossOver explode when trying to inject using the endpoint method. This is basically another case of .Net Downloader/Aria2c platform-specific defaults.

We'll need to note this in the official Dalamud release announcement too.