### PR TITLE
feat: add error message for deleted Dalamud.Boot DLL

### DIFF
--- a/src/XIVLauncher/Dalamud/DalamudLauncher.cs
+++ b/src/XIVLauncher/Dalamud/DalamudLauncher.cs
@@ -138,9 +138,20 @@ namespace XIVLauncher.Dalamud
             if (_loadMethod == DalamudLoadMethod.EntryPoint)
             {
                 SetDllDirectory(DalamudUpdater.Runner.DirectoryName);
-                if (0 != RewriteRemoteEntryPointW(gameProcess.Handle, Path.Combine(_gamePath.FullName, "game", gameProcess.ProcessName + ".exe"), JsonConvert.SerializeObject(startInfo)))
+                try
                 {
-                    CustomMessageBox.Show(runnerErrorMessage,
+                    if (0 != RewriteRemoteEntryPointW(gameProcess.Handle,
+                            Path.Combine(_gamePath.FullName, "game", gameProcess.ProcessName + ".exe"),
+                            JsonConvert.SerializeObject(startInfo)))
+                    {
+                        CustomMessageBox.Show(runnerErrorMessage,
+                            "XIVLauncher Error", MessageBoxButton.OK, MessageBoxImage.Error);
+                        return;
+                    }
+                }
+                catch (DllNotFoundException)
+                {
+                    CustomMessageBox.Show(Loc.Localize("AntivirusDeletedBoot", "The Dalamud boot DLL could not be found.\n\nIt was likely deleted by your antivirus software. Please add an exception for the XIVLauncher folder and try again."),
                         "XIVLauncher Error", MessageBoxButton.OK, MessageBoxImage.Error);
                     return;
                 }


### PR DESCRIPTION
This adds an error message box for when Dalamud.Boot has been deleted. #659 and #637 report this. I couldn't find an existing localized string on Crowdin to reuse, but let me know if there is actually one and I'll update this.