### PR TITLE
Use TwoLetterISORegion because ThreeLetterISORegion is broken on Wine

### DIFF
--- a/src/XIVLauncher/Util.cs
+++ b/src/XIVLauncher/Util.cs
@@ -68,6 +68,7 @@ namespace XIVLauncher
         public static bool IsRegionNorthAmerica()
         {
             return RegionInfo.CurrentRegion.ThreeLetterISORegionName is "USA" or "MEX" or "CAN";
+            return RegionInfo.CurrentRegion.TwoLetterISORegionName is "US" or "MX" or "CA";
         }
 
         public static string GetAssemblyVersion()

--- a/src/XIVLauncher/Util.cs
+++ b/src/XIVLauncher/Util.cs
@@ -67,7 +67,6 @@ namespace XIVLauncher
         /// </summary>
         public static bool IsRegionNorthAmerica()
         {
-            return RegionInfo.CurrentRegion.ThreeLetterISORegionName is "USA" or "MEX" or "CAN";
             return RegionInfo.CurrentRegion.TwoLetterISORegionName is "US" or "MX" or "CA";
         }
 


### PR DESCRIPTION
Wine reports a blank value when `RegionInfo.CurrentRegion.ThreeLetterISORegionName` is used. This always defaults Wine/CrossOver users over to en-gb even when they should get en-us. 

For unknown reasons, `RegionInfo.CurrentRegion.TwoLetterISORegionName` works just fine though, so this replaces the old check with a "works on all platforms" one. Locale handling is pain.