### PR TITLE
Do not exit when rate limited

### DIFF
--- a/src/XIVLauncher/Updates.cs
+++ b/src/XIVLauncher/Updates.cs
@@ -60,7 +60,14 @@ namespace XIVLauncher
                                 "XIVLauncher",
                                  MessageBoxButton.OK,
                                  MessageBoxImage.Error);
-                System.Environment.Exit(1);
+
+#if !XL_NOAUTOUPDATE
+                // Don't exit if the client was rate limited 
+                if (ex.Message?.Contains("403") == true)
+                    OnUpdateCheckFinished?.Invoke(this, null);
+                else
+#endif
+                    System.Environment.Exit(1);
             }
 
 

--- a/src/XIVLauncher/Updates.cs
+++ b/src/XIVLauncher/Updates.cs
@@ -63,7 +63,7 @@ namespace XIVLauncher
 
 #if !XL_NOAUTOUPDATE
                 // Don't exit if the client was rate limited 
-                if (ex.Message?.Contains("403") == true)
+                if (ex is System.Net.Http.HttpRequestException && ex.Message?.Contains("403") == true)
                     OnUpdateCheckFinished?.Invoke(this, null);
                 else
 #endif


### PR DESCRIPTION
I am behind a double or triple NAT. GitHub's rate limiting is by IP. There is someone on my IP that immediately blows through the GitHub rate limit. It's frustrating as there is nothing I can do about it. XIVLauncher exits if it can't check for an update. I have changed this to allow the app to continue if the exception was caused from rate limiting.