### PR TITLE
Prevent remote VerifyFiles from timing out after 30sec

### DIFF
--- a/src/XIVLauncher.PatchInstaller/IndexedZiPatch/IndexedZiPatchIndexRemoteInstaller.cs
+++ b/src/XIVLauncher.PatchInstaller/IndexedZiPatch/IndexedZiPatchIndexRemoteInstaller.cs
@@ -149,7 +149,7 @@ namespace XIVLauncher.PatchInstaller.IndexedZiPatch
         {
             var writer = GetRequestCreator(WorkerInboundOpcode.VerifyFiles, cancellationToken);
             writer.Write(concurrentCount);
-            await WaitForResult(writer);
+            await WaitForResult(writer, 864000000);
         }
 
         public async Task MarkFileAsMissing(int targetIndex, CancellationToken? cancellationToken = null)


### PR DESCRIPTION
Timeouts for all remote operations are 30sec except VerifyFiles and Install. 