### PR TITLE
Multiple fixes for verify/repair

### DIFF
--- a/src/XIVLauncher/Windows/GameRepairProgressWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/GameRepairProgressWindow.xaml.cs
@@ -1,4 +1,5 @@
-﻿using System.Timers;
+﻿using System;
+using System.Timers;
 using System.Windows;
 using XIVLauncher.Common;
 using XIVLauncher.Game;
@@ -43,7 +44,7 @@ namespace XIVLauncher.Windows
                 }
 
                 InfoTextBlock.Text = $"{_verify.CurrentFile}";
-                StatusTextBlock.Text = $"{this._verify.Index + 1}/{_verify.PatchIndexLength} - {Util.BytesToString(this._verify.Progress)}/{Util.BytesToString(_verify.Total)}";
+                StatusTextBlock.Text = $"{Math.Min(_verify.TaskIndex + 1, _verify.TaskCount)}/{_verify.TaskCount} - {Util.BytesToString(this._verify.Progress)}/{Util.BytesToString(_verify.Total)}";
                 this.Progress.Value = _verify.Total != 0 ? 100.0 * _verify.Progress / _verify.Total : 0;
             });
         }

--- a/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
@@ -500,7 +500,7 @@ namespace XIVLauncher.Windows.ViewModel
 
                 verify.Start();
 
-                while (verify.State != PatchVerifier.VerifyState.Done && verify.State != PatchVerifier.VerifyState.Cancelled)
+                while (verify.State != PatchVerifier.VerifyState.Done && verify.State != PatchVerifier.VerifyState.Cancelled && verify.State != PatchVerifier.VerifyState.Error)
                 {
                     await Task.Delay(1000);
                 }
@@ -521,6 +521,12 @@ namespace XIVLauncher.Windows.ViewModel
 
                     Reactivate();
                     return true;
+                }
+                else if (verify.State == PatchVerifier.VerifyState.Error)
+                {
+                    // TODO: Display error
+                    CustomMessageBox.Show($"Last exception: {verify.LastException}",
+                        "XIVLauncher", MessageBoxButton.OK, MessageBoxImage.Error);
                 }
 
                 mutex.Close();


### PR DESCRIPTION
* Prevent progress from overshooting
* Workaround Dispose problems
* Separate progress/verify events
* Handle UAC dialog cancelling cases
* Add placeholder code for showing user error dialog
* Make PatchVerifier task actually end
* Add remote call for setting worker process' priority
* Make PatchVerifier set worker process' priority to Idle

