### PR TITLE
Attempt to fix multithreading problems

### DIFF
--- a/src/XIVLauncher.Common/Patching/IndexedZiPatch/IndexedZiPatchOperations.cs
+++ b/src/XIVLauncher.Common/Patching/IndexedZiPatch/IndexedZiPatchOperations.cs
@@ -107,7 +107,7 @@ namespace XIVLauncher.Common.Patching.IndexedZiPatch
 
             try
             {
-                verifier.SetTargetStreamsFromPathReadOnly(gameRootPath);
+                verifier.SetTargetFilesFromAllInRootPath(gameRootPath);
                 await verifier.VerifyFiles(8, cancellationToken);
             }
             finally
@@ -122,7 +122,7 @@ namespace XIVLauncher.Common.Patching.IndexedZiPatch
         public static async Task RepairFromPatchFileIndexFromFile(IndexedZiPatchIndex patchIndex, string gameRootPath, string patchFileRootDir, int concurrentCount, CancellationToken? cancellationToken = null)
         {
             using var verifier = await VerifyFromZiPatchIndex(patchIndex, gameRootPath, cancellationToken);
-            verifier.SetTargetStreamsFromPathReadWriteForMissingFiles(gameRootPath);
+            verifier.SetTargetFilesFromMissingFilesInRootPath(gameRootPath);
             for (var i = 0; i < patchIndex.Sources.Count; i++)
                 verifier.QueueInstall(i, new FileInfo(Path.Combine(patchFileRootDir, patchIndex.Sources[i])));
             await verifier.Install(concurrentCount, cancellationToken);
@@ -133,7 +133,7 @@ namespace XIVLauncher.Common.Patching.IndexedZiPatch
         public static async Task RepairFromPatchFileIndexFromUri(IndexedZiPatchIndex patchIndex, string gameRootPath, HttpClient client, string baseUri, int concurrentCount, CancellationToken? cancellationToken = null)
         {
             using var verifier = await VerifyFromZiPatchIndex(patchIndex, gameRootPath, cancellationToken);
-            verifier.SetTargetStreamsFromPathReadWriteForMissingFiles(gameRootPath);
+            verifier.SetTargetFilesFromMissingFilesInRootPath(gameRootPath);
             for (var i = 0; i < patchIndex.Sources.Count; i++)
                 verifier.QueueInstall(i, client, baseUri + patchIndex.Sources[i], null, concurrentCount);
 

--- a/src/XIVLauncher/Game/Patch/PatchVerifier.cs
+++ b/src/XIVLauncher/Game/Patch/PatchVerifier.cs
@@ -140,7 +140,14 @@ namespace XIVLauncher.Game.Patch
             while ((now - _reportedProgresses.First().Item1) > 10 * 1000 * 8000)
                 _reportedProgresses.RemoveAt(0);
 
-            Speed = (_reportedProgresses.Last().Item2 - _reportedProgresses.First().Item2) * 10 * 1000 * 1000 / (_reportedProgresses.Last().Item1 - _reportedProgresses.First().Item1);
+            try
+            {
+                Speed = (_reportedProgresses.Last().Item2 - _reportedProgresses.First().Item2) * 10 * 1000 * 1000 / (_reportedProgresses.Last().Item1 - _reportedProgresses.First().Item1);
+            }
+            catch (DivideByZeroException)
+            {
+                Speed = 0;
+            }
         }
 
         private async Task RunVerifier()
@@ -180,8 +187,6 @@ namespace XIVLauncher.Game.Patch
                                     Progress = Math.Min(progress, max);
                                     Total = max;
                                     RecordProgressForEstimation();
-
-                                    Log.Verbose("[{0}/{1}] {2} {3}... {4:0.00}/{5:0.00}MB ({6:00.00}%)", targetIndex + 1, TaskCount, "Checking", CurrentFile, progress / 1048576.0, max / 1048576.0, 100.0 * progress / max);
                                 }
 
                                 void UpdateInstallProgress(int sourceIndex, long progress, long max)
@@ -191,8 +196,6 @@ namespace XIVLauncher.Game.Patch
                                     Progress = Math.Min(progress, max);
                                     Total = max;
                                     RecordProgressForEstimation();
-
-                                    Log.Verbose("[{0}/{1}] {2} {3}... {4:0.00}/{5:0.00}MB ({6:00.00}%)", sourceIndex + 1, TaskCount, "Installing", CurrentFile, progress / 1048576.0, max / 1048576.0, 100.0 * progress / max);
                                 }
 
                                 try
@@ -206,7 +209,7 @@ namespace XIVLauncher.Game.Patch
 
                                     var adjustedGamePath = Path.Combine(App.Settings.GamePath.FullName, patchIndex.ExpacVersion == IndexedZiPatchIndex.EXPAC_VERSION_BOOT ? "boot" : "game");
 
-                                    await remote.SetTargetStreamsFromPathReadOnly(adjustedGamePath);
+                                    await remote.SetTargetFilesFromAllInRootPath(adjustedGamePath);
                                     // TODO: check one at a time if random access is slow?
                                     await remote.VerifyFiles(Environment.ProcessorCount, _cancellationTokenSource.Token);
 
@@ -215,7 +218,7 @@ namespace XIVLauncher.Game.Patch
                                     var missing = await remote.GetMissingPartIndicesPerPatch();
                                     NumBrokenFiles += (await remote.GetMissingPartIndicesPerTargetFile()).Count(x => x.Any());
 
-                                    await remote.SetTargetStreamsFromPathReadWriteForMissingFiles(adjustedGamePath);
+                                    await remote.SetTargetFilesFromMissingFilesInRootPath(adjustedGamePath);
                                     var prefix = patchIndex.ExpacVersion == IndexedZiPatchIndex.EXPAC_VERSION_BOOT ? "boot:" : $"ex{patchIndex.ExpacVersion}:";
                                     for (var i = 0; i < patchIndex.Sources.Count; i++)
                                     {


### PR DESCRIPTION
* Use Array.SyncRoot instead of array instance itself
* Create FileStream per thread instead of sharing it with a lock