### PR TITLE
RoamingPath override expands environment variables

### DIFF
--- a/src/XIVLauncher.Common/Paths.cs
+++ b/src/XIVLauncher.Common/Paths.cs
@@ -16,7 +16,7 @@ namespace XIVLauncher.Common
 
         public static void OverrideRoamingPath(string path)
         {
-            RoamingPath = path;
+            RoamingPath = Environment.ExpandEnvironmentVariables(path);
         }
     }
 }


### PR DESCRIPTION
Environment variables such as `%AppData%` can be used to set RoamingPath