### PR TITLE
Do not assign owner window on ShowDialog if owner isn't visible

### DIFF
--- a/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
@@ -772,7 +772,8 @@ namespace XIVLauncher.Windows.ViewModel
                 var progressDialog = _window.Dispatcher.Invoke(() =>
                 {
                     var d = new GameRepairProgressWindow(verify);
-                    d.Owner = _window;
+                    if (_window.IsVisible)
+                        d.Owner = _window;
                     d.Show();
                     d.Activate();
                     return d;
@@ -1112,7 +1113,8 @@ namespace XIVLauncher.Windows.ViewModel
             PatchDownloadDialog progressDialog = _window.Dispatcher.Invoke(() =>
             {
                 var d = new PatchDownloadDialog(patcher);
-                d.Owner = _window;
+                if (_window.IsVisible)
+                    d.Owner = _window;
                 d.Show();
                 d.Activate();
                 return d;


### PR DESCRIPTION
Fixes the following error.

```
System.InvalidOperationException: Cannot set Owner property to a Window that has not been shown previously.
   at System.Windows.Window.set_Owner(Window value)
   at XIVLauncher.Windows.ViewModel.MainWindowViewModel.<>c__DisplayClass34_0.<TryHandlePatchAsync>b__0() in D:\a\FFXIVQuickLauncher\FFXIVQuickLauncher\src\XIVLauncher\Windows\ViewModel\MainWindowViewModel.cs:line 1116
   at System.Windows.Threading.DispatcherOperation`1.InvokeDelegateCore()
   at System.Windows.Threading.DispatcherOperation.InvokeImpl()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at System.Windows.Threading.DispatcherOperation.Wait(TimeSpan timeout)
   at System.Windows.Threading.Dispatcher.InvokeImpl(DispatcherOperation operation, CancellationToken cancellationToken, TimeSpan timeout)
   at System.Windows.Threading.Dispatcher.Invoke[TResult](Func`1 callback, DispatcherPriority priority, CancellationToken cancellationToken, TimeSpan timeout)
   at System.Windows.Threading.Dispatcher.Invoke[TResult](Func`1 callback)
   at XIVLauncher.Windows.ViewModel.MainWindowViewModel.<TryHandlePatchAsync>d__34.MoveNext()
--- End of stack trace from previous location where exception was thrown ---
   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw()
   at System.Runtime.CompilerServices.TaskAwaiter.HandleNonSuccessAndDebuggerNotification(Task task)
   at XIVLauncher.Windows.ViewModel.MainWindowViewModel.<HandleBootCheck>d__33.MoveNext() in D:\a\FFXIVQuickLauncher\FFXIVQuickLauncher\src\XIVLauncher\Windows\ViewModel\MainWindowViewModel.cs:line 1071
```