### PR TITLE
Verify/Repair improvements

### DIFF
--- a/src/XIVLauncher/Windows/ViewModel/GameRepairProgressWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/GameRepairProgressWindowViewModel.cs
@@ -13,6 +13,7 @@ namespace XIVLauncher.Windows.ViewModel
 
         private void SetupLoc()
         {
+            DownloadingMetaLoc = Loc.Localize("NowDownloadingMeta", "Downloading meta files...");
             VerifyingLoc = Loc.Localize("NowVerifying", "Verifying game files...");
             RepairingLoc = Loc.Localize("NowRepairing", "Repairing game files...");
             ConnectingLoc = Loc.Localize("NowRepairingConnecting", "Connecting...");
@@ -24,6 +25,7 @@ namespace XIVLauncher.Windows.ViewModel
             EstimatedRemainingDurationWithHoursLoc = Loc.Localize("EstimatedRemainingDurationWithHours", "{0:00}:{1:00}:{2:00} remaining");
         }
 
+        public string DownloadingMetaLoc { get; private set; }
         public string VerifyingLoc { get; private set; }
         public string RepairingLoc { get; private set; }
         public string ConnectingLoc { get; private set; }

--- a/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
@@ -753,22 +753,6 @@ namespace XIVLauncher.Windows.ViewModel
                 Hide();
                 IsEnabled = false;
 
-                try
-                {
-                    await verify.GetPatchMeta().ConfigureAwait(false);
-                }
-                catch (NoVersionReferenceException ex)
-                {
-                    Log.Error(ex, "No version reference found");
-
-                    CustomMessageBox.Show(
-                        Loc.Localize("NoVersionReferenceError",
-                            "The version of the game you are on cannot be repaired by XIVLauncher yet, as reference information is not yet available.\nPlease try again later."),
-                        Loc.Localize("LoginNoOauthTitle", "Login issue"), MessageBoxButton.OK, MessageBoxImage.Error, parentWindow: _window);
-
-                    return false;
-                }
-
                 var progressDialog = _window.Dispatcher.Invoke(() =>
                 {
                     var d = new GameRepairProgressWindow(verify);
@@ -822,15 +806,29 @@ namespace XIVLauncher.Windows.ViewModel
 
                         case PatchVerifier.VerifyState.Error:
                             doLogin = false;
-                            doVerify = CustomMessageBox.Builder
-                                .NewFrom(verify.LastException, "PatchVerifier")
-                                .WithAppendText("\n\n")
-                                .WithAppendText(Loc.Localize("GameRepairError", "An error occurred while repairing the game files.\nYou may have to reinstall the game."))
-                                .WithImage(MessageBoxImage.Exclamation)
-                                .WithButtons(MessageBoxButton.OKCancel)
-                                .WithOkButtonText(Loc.Localize("GameRepairSuccess_TryAgain", "_Try again"))
-                                .WithParentWindow(_window)
-                                .Show() == MessageBoxResult.OK;
+                            if (verify.LastException is NoVersionReferenceException)
+                            {
+                                doVerify = CustomMessageBox.Builder
+                                    .NewFrom(Loc.Localize("NoVersionReferenceError",
+                                        "The version of the game you are on cannot be repaired by XIVLauncher yet, as reference information is not yet available.\nPlease try again later."))
+                                    .WithImage(MessageBoxImage.Exclamation)
+                                    .WithButtons(MessageBoxButton.OKCancel)
+                                    .WithOkButtonText(Loc.Localize("GameRepairSuccess_TryAgain", "_Try again"))
+                                    .WithParentWindow(_window)
+                                    .Show() == MessageBoxResult.OK;
+                            }
+                            else
+                            {
+                                doVerify = CustomMessageBox.Builder
+                                    .NewFrom(verify.LastException, "PatchVerifier")
+                                    .WithAppendText("\n\n")
+                                    .WithAppendText(Loc.Localize("GameRepairError", "An error occurred while repairing the game files.\nYou may have to reinstall the game."))
+                                    .WithImage(MessageBoxImage.Exclamation)
+                                    .WithButtons(MessageBoxButton.OKCancel)
+                                    .WithOkButtonText(Loc.Localize("GameRepairSuccess_TryAgain", "_Try again"))
+                                    .WithParentWindow(_window)
+                                    .Show() == MessageBoxResult.OK;
+                            }
                             break;
 
                         case PatchVerifier.VerifyState.Cancelled:


### PR DESCRIPTION
* Ignore local patch files when the first attempt fails, as local copy of patches may be corrupt.
* Set `.ConfigureAwait(false)` for all awaits in PatchVerifier, as none of those are being called from a thread with messaging loop.
* Show meta file download progress, as meta file sizes are not negligible.