### PR TITLE
Accept --steamticket command line parameter

### DIFF
--- a/src/XIVLauncher.Common/Encryption/Ticket.cs
+++ b/src/XIVLauncher.Common/Encryption/Ticket.cs
@@ -31,9 +31,15 @@ public class Ticket
         if (ticketBytes == null)
             return null;
 
-        var time = 60 * ((steam.GetServerRealTime() - 5) / 60);
+        return EncryptAuthSessionTicket(ticketBytes, steam.GetServerRealTime());
+    }
 
-        var ticketString = BitConverter.ToString(ticketBytes).Replace("-", "").ToLower();
+    public static Ticket EncryptAuthSessionTicket(byte[] ticket, uint time)
+    {
+        time -= 5;
+        time -= time % 60; // Time should be rounded to nearest minute.
+
+        var ticketString = BitConverter.ToString(ticket).Replace("-", "").ToLower();
         var rawTicketBytes = Encoding.ASCII.GetBytes(ticketString);
 
         var rawTicket = new byte[rawTicketBytes.Length + 1];

--- a/src/XIVLauncher.Common/Game/Launcher.cs
+++ b/src/XIVLauncher.Common/Game/Launcher.cs
@@ -19,6 +19,7 @@ namespace XIVLauncher.Common.Game
     public class Launcher
     {
         private readonly ISteam steam;
+        private readonly byte[] steamTicket;
         private readonly IUniqueIdCache uniqueIdCache;
         private readonly ISettings settings;
         private readonly HttpClient client;
@@ -35,6 +36,11 @@ namespace XIVLauncher.Common.Game
                 UseCookies = false,
             };
             this.client = new HttpClient(handler);
+        }
+
+        public Launcher(byte[] steamTicket, IUniqueIdCache uniqueIdCache, ISettings settings) : this(steam: null, uniqueIdCache, settings)
+        {
+            this.steamTicket = steamTicket;
         }
 
         // The user agent for frontier pages. {0} has to be replaced by a unique computer id and its checksum
@@ -84,36 +90,44 @@ namespace XIVLauncher.Common.Game
 
             if (isSteam)
             {
-                try
+                if (this.steamTicket != null)
                 {
+                    steamTicket = Ticket.EncryptAuthSessionTicket(this.steamTicket, (uint) DateTimeOffset.UtcNow.ToUnixTimeSeconds());
+                    Log.Information("Using predefined steam ticket");
+                }
+                else
+                {
+                    try
+                    {
+                        if (!this.steam.IsValid)
+                        {
+                            this.steam.Initialize(isFreeTrial ? Constants.STEAM_FT_APP_ID : Constants.STEAM_APP_ID);
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        Log.Error(ex, "Could not initialize Steam");
+                        throw new SteamException("SteamAPI_Init() failed.", ex);
+                    }
+
                     if (!this.steam.IsValid)
                     {
-                        this.steam.Initialize(isFreeTrial ? Constants.STEAM_FT_APP_ID : Constants.STEAM_APP_ID);
+                        throw new SteamException("Steam did not initialize successfully. Please restart Steam and try again.");
                     }
-                }
-                catch (Exception ex)
-                {
-                    Log.Error(ex, "Could not initialize Steam");
-                    throw new SteamException("SteamAPI_Init() failed.", ex);
-                }
 
-                if (!this.steam.IsValid)
-                {
-                    throw new SteamException("Steam did not initialize successfully. Please restart Steam and try again.");
-                }
+                    if (!this.steam.BLoggedOn())
+                    {
+                        throw new SteamException("Not logged into Steam, or Steam is running in offline mode. Please log in and try again.");
+                    }
 
-                if (!this.steam.BLoggedOn())
-                {
-                    throw new SteamException("Not logged into Steam, or Steam is running in offline mode. Please log in and try again.");
-                }
-
-                try
-                {
-                    steamTicket = await Ticket.Get(steam).ConfigureAwait(true);
-                }
-                catch (Exception ex)
-                {
-                    throw new SteamException("Could not request auth ticket.", ex);
+                    try
+                    {
+                        steamTicket = await Ticket.Get(steam).ConfigureAwait(true);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new SteamException("Could not request auth ticket.", ex);
+                    }
                 }
 
                 if (steamTicket == null)

--- a/src/XIVLauncher.Common/Game/Launcher.cs
+++ b/src/XIVLauncher.Common/Game/Launcher.cs
@@ -18,13 +18,13 @@ namespace XIVLauncher.Common.Game
 {
     public class Launcher
     {
-        private readonly ISteam steam;
-        private readonly byte[] steamTicket;
+        private readonly ISteam? steam;
+        private readonly byte[]? steamTicket;
         private readonly IUniqueIdCache uniqueIdCache;
         private readonly ISettings settings;
         private readonly HttpClient client;
 
-        public Launcher(ISteam steam, IUniqueIdCache uniqueIdCache, ISettings settings)
+        public Launcher(ISteam? steam, IUniqueIdCache uniqueIdCache, ISettings settings)
         {
             this.steam = steam;
             this.uniqueIdCache = uniqueIdCache;
@@ -97,6 +97,8 @@ namespace XIVLauncher.Common.Game
                 }
                 else
                 {
+                    Debug.Assert(this.steam != null);
+
                     try
                     {
                         if (!this.steam.IsValid)

--- a/src/XIVLauncher/App.xaml.cs
+++ b/src/XIVLauncher/App.xaml.cs
@@ -41,6 +41,7 @@ namespace XIVLauncher
         private MainWindow _mainWindow;
 
         public static bool GlobalIsDisableAutologin { get; private set; }
+        public static byte[] GlobalSteamTicket { get; private set; }
         public static DalamudUpdater DalamudUpdater { get; private set; }
 
         public static Brush UaBrush = new LinearGradientBrush(new GradientStopCollection()
@@ -337,6 +338,13 @@ namespace XIVLauncher
                     {
                         accountName = arg.Substring(arg.IndexOf("=", StringComparison.InvariantCulture) + 1);
                         App.Settings.CurrentAccountId = accountName;
+                    }
+
+                    // Check if the steam ticket parameter is provided, use it later to skip steam integration
+                    if (arg.StartsWith("--steamticket=", StringComparison.Ordinal))
+                    {
+                        string steamTicket = arg.Substring(arg.IndexOf("=", StringComparison.InvariantCulture) + 1);
+                        GlobalSteamTicket = Convert.FromBase64String(steamTicket);
                     }
 
                     // Override client launch language by parameter

--- a/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
@@ -35,7 +35,7 @@ namespace XIVLauncher.Windows.ViewModel
 
         public bool IsLoggingIn;
 
-        public Launcher Launcher { get; private set; } = new(App.Steam, CommonUniqueIdCache.Instance, CommonSettings.Instance);
+        public Launcher Launcher { get; private set; }
 
         public AccountManager AccountManager { get; private set; } = new(App.Settings);
 
@@ -63,6 +63,10 @@ namespace XIVLauncher.Windows.ViewModel
             LoginNoStartCommand = new SyncCommand(GetLoginFunc(AfterLoginAction.UpdateOnly), () => !IsLoggingIn);
             LoginNoDalamudCommand = new SyncCommand(GetLoginFunc(AfterLoginAction.StartWithoutDalamud), () => !IsLoggingIn);
             LoginRepairCommand = new SyncCommand(GetLoginFunc(AfterLoginAction.Repair), () => !IsLoggingIn);
+
+            Launcher = App.GlobalSteamTicket == null ?
+                new(App.Steam, CommonUniqueIdCache.Instance, CommonSettings.Instance) :
+                new(App.GlobalSteamTicket, CommonUniqueIdCache.Instance, CommonSettings.Instance);
         }
 
         private void InstallerOnFail()


### PR DESCRIPTION
Allows user to provide --steamticket=***** command line parameter as a base64 encoded string.

I am working on an open-source alternative to using steam using this third-party library: https://github.com/DoctorMcKay/node-steam-user/

The idea would be to obtain the steam auth session ticket and pass it to XIVLauncher to do the heavy lifting. This would be beneficial to any user with issues running steam, or those attempting to launch multiple clients without logging in and out of steam.