### PR TITLE
Adds launch option to read steamticket from file

### DIFF
--- a/src/XIVLauncher/App.xaml.cs
+++ b/src/XIVLauncher/App.xaml.cs
@@ -347,6 +347,13 @@ namespace XIVLauncher
                         GlobalSteamTicket = Convert.FromBase64String(steamTicket);
                     }
 
+                    // same as above but read it from a predefined file
+                    if (arg.StartsWith("--steamticketfile", StringComparison.Ordinal))
+                    {
+                        string steamTicket = File.ReadAllText(Path.Combine(Paths.RoamingPath, "ticket.txt"));
+                        GlobalSteamTicket = Convert.FromBase64String(steamTicket);
+                    }
+
                     // Override client launch language by parameter
                     if (arg.StartsWith("--clientlang=", StringComparison.Ordinal))
                     {


### PR DESCRIPTION
This PR adds a command line flag to read the steam ticket from a ticket.txt in `Paths.RoamingPath`. This way it can be easier placed by a prelaunch script from lutris.