### PR TITLE
Upstream Squirrel => Clowd.Squirrel

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -38,7 +38,6 @@ jobs:
           $current = ConvertFrom-Json -InputObject $releases.Content | Select-Object -First 1
           $refver = $env:GITHUB_REF -replace '.*/'
           echo "::set-output name=version::$refver"
-          nuget pack .\XIVLauncher.nuspec -properties version=$refver
           mkdir Releases
           cp .\XIVLauncher\Resources\CHANGELOG.txt .\Releases\
           $release_file = $current.assets | Where-Object -Property name -Value RELEASES -EQ
@@ -47,9 +46,9 @@ jobs:
           Invoke-WebRequest -Uri $delta_file.browser_download_url -OutFile ".\Releases\$($delta_file.name)"
           $full_file = $current.assets | Where-Object -Property name -Value "*full.nupkg" -Like
           Invoke-WebRequest -Uri $full_file.browser_download_url -OutFile ".\Releases\$($full_file.name)"
-          $setup_file = $current.assets | Where-Object -Property name -Value "Setup.exe" -EQ
-          Invoke-WebRequest -Uri $setup_file.browser_download_url -OutFile .\Releases\Setup.exe
-           ~\.nuget\packages\squirrel.windows\1.9.1\tools\Squirrel.exe --no-msi --releasify .\XIVLauncher.$refver.nupkg --setupIcon=.\XIVLauncher\Resources\dalamud_icon.ico --icon=.\XIVLauncher\Resources\dalamud_icon.ico
+          $setup_file = $current.assets | Where-Object -Property name -Match "(XIVLauncher)?Setup\.exe"
+          Invoke-WebRequest -Uri $setup_file.browser_download_url -OutFile .\Releases\XIVLauncherSetup.exe
+           ~\.nuget\packages\clowd.squirrel\2.8.40\tools\Squirrel.exe pack -p .\bin\ --packTitle XIVLauncher --packId XIVLauncher --packVersion $refver --packAuthors goatsoft -i .\XIVLauncher\Resources\dalamud_icon.ico --appIcon .\XIVLauncher\Resources\dalamud_icon.ico -f 'net472,vcredist143-x64'
           Start-Sleep -s 60
           rm ".\Releases\$($delta_file.name)"
           rm ".\Releases\$($full_file.name)"

--- a/src/XIVLauncher/App.xaml.cs
+++ b/src/XIVLauncher/App.xaml.cs
@@ -11,6 +11,7 @@ using Config.Net;
 using Newtonsoft.Json;
 using Serilog;
 using Serilog.Events;
+using Squirrel;
 using XIVLauncher.Common;
 using XIVLauncher.Common.Dalamud;
 using XIVLauncher.Common.Game;
@@ -52,6 +53,11 @@ namespace XIVLauncher
 
         public App()
         {
+            SquirrelAwareApp.HandleEvents(
+                onInitialInstall: (v, t) => t.CreateShortcutForThisExe(),
+                onAppUpdate: (v, t) => t.CreateShortcutForThisExe(),
+                onAppUninstall: (v, t) => t.RemoveShortcutForThisExe());
+
             // HW rendering commonly causes issues with material design, so we turn it off by default for now
             try
             {
@@ -88,7 +94,7 @@ namespace XIVLauncher
                              .WriteTo.Debug()
                              .MinimumLevel.Verbose()
 #else
-                            .MinimumLevel.Information()
+                             .MinimumLevel.Information()
 #endif
                              .CreateLogger();
 
@@ -159,8 +165,7 @@ namespace XIVLauncher
                     _updateWindow = new UpdateLoadingDialog();
                     _updateWindow.Show();
 
-                    var updateMgr = new Updates();
-                    updateMgr.OnUpdateCheckFinished += OnUpdateCheckFinished;
+                    var updateMgr = new Updates(OnUpdateCheckFinished);
 
                     ChangelogWindow changelogWindow = null;
                     try

--- a/src/XIVLauncher/Properties/AssemblyInfo.cs
+++ b/src/XIVLauncher/Properties/AssemblyInfo.cs
@@ -1,3 +1,0 @@
-using System.Reflection;
-
-[assembly: AssemblyMetadata("SquirrelAwareVersion", "1")]

--- a/src/XIVLauncher/Properties/app.manifest
+++ b/src/XIVLauncher/Properties/app.manifest
@@ -1,0 +1,66 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+
+  <!-- Makes Squirrel aware that this is the proper executable -->
+  <SquirrelAwareVersion xmlns="urn:schema-squirrel-com:asm.v1">1</SquirrelAwareVersion>
+
+  <assemblyIdentity version="1.0.0.0" name="goatsoft.XIVLauncher.app"/>
+
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- A list of the Windows versions that this application has been tested on
+           and is designed to work with. Uncomment the appropriate elements
+           and Windows will automatically select the most compatible environment. -->
+
+      <!-- Windows Vista -->
+      <!--<supportedOS Id="{e2011457-1546-43c5-a5fe-008deee3d3f0}" />-->
+
+      <!-- Windows 7 -->
+      <!--<supportedOS Id="{35138b9a-5d96-4fbd-8e2d-a2440225f93a}" />-->
+
+      <!-- Windows 8 -->
+      <!--<supportedOS Id="{4a2f28e3-53b9-4441-ba9c-d69d4a4a6e38}" />-->
+
+      <!-- Windows 8.1 -->
+      <supportedOS Id="{1f676c76-80e1-4239-95bb-83d0f6d0da78}" />
+
+      <!-- Windows 10 and 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}" />
+
+	    <!-- Highest version of Windows 10/11 tested on. -->
+      <maxversiontested Id="10.0.22000.556"/>
+    </application>
+  </compatibility>
+
+  <!-- Indicates that the application is DPI-aware and will not be automatically scaled by Windows at higher
+       DPIs. Windows Presentation Foundation (WPF) applications are automatically DPI-aware and do not need 
+       to opt in. Windows Forms applications targeting .NET Framework 4.6 that opt into this setting, should 
+       also set the 'EnableWindowsFormsHighDpiAutoResizing' setting to 'true' in their app.config. 
+       
+       Makes the application long-path aware. See https://docs.microsoft.com/windows/win32/fileio/maximum-file-path-limitation -->
+  <!--
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true</dpiAware>
+      <longPathAware xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">true</longPathAware>
+    </windowsSettings>
+  </application>
+  -->
+
+  <!-- Enable themes for Windows common controls and dialogs (Windows XP and later) -->
+  <!--
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+          type="win32"
+          name="Microsoft.Windows.Common-Controls"
+          version="6.0.0.0"
+          processorArchitecture="*"
+          publicKeyToken="6595b64144ccf1df"
+          language="*"
+        />
+    </dependentAssembly>
+  </dependency>
+  -->
+
+</assembly>

--- a/src/XIVLauncher/Updates.cs
+++ b/src/XIVLauncher/Updates.cs
@@ -7,11 +7,13 @@ using Serilog;
 using Squirrel;
 using XIVLauncher.Windows;
 
+#nullable enable
+
 namespace XIVLauncher
 {
     class Updates
     {
-        public event Action<bool> OnUpdateCheckFinished;
+        public event Action<bool>? OnUpdateCheckFinished;
 
         public async Task Run(bool downloadPrerelease, ChangelogWindow changelogWindow)
         {
@@ -26,18 +28,20 @@ namespace XIVLauncher
 
             try
             {
-                ReleaseEntry newRelease = null;
+                ReleaseEntry? newRelease = null;
 
                 using (var updateManager = new UpdateManager(url, "XIVLauncher"))
                 {
                     // TODO: is this allowed?
                     SquirrelAwareApp.HandleEvents(
-                        onInitialInstall: v => updateManager.CreateShortcutForThisExe(),
-                        onAppUpdate: v => updateManager.CreateShortcutForThisExe(),
-                        onAppUninstall: v => updateManager.RemoveShortcutForThisExe());
+                        onInitialInstall: (v, t) => updateManager.CreateShortcutForThisExe(),
+                        onAppUpdate: (v, t) => updateManager.CreateShortcutForThisExe(),
+                        onAppUninstall: (v, t) => updateManager.RemoveShortcutForThisExe());
 
+#pragma warning disable CA2007 // Consider calling ConfigureAwait on the awaited task
                     var a = await updateManager.CheckForUpdate();
                     newRelease = await updateManager.UpdateApp();
+#pragma warning restore CA2007 // Consider calling ConfigureAwait on the awaited task
                 }
 
                 if (newRelease != null)
@@ -89,3 +93,5 @@ namespace XIVLauncher
         }
     }
 }
+
+#nullable disable

--- a/src/XIVLauncher/XIVLauncher.csproj
+++ b/src/XIVLauncher/XIVLauncher.csproj
@@ -37,6 +37,7 @@
 
   <PropertyGroup>
     <ApplicationIcon>Resources\dalamud_icon.ico</ApplicationIcon>
+    <ApplicationManifest>Properties\app.manifest</ApplicationManifest>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
@@ -72,6 +73,7 @@
   <ItemGroup>
     <PackageReference Include="AdysTech.CredentialManager" Version="1.8.0" />
     <PackageReference Include="CheapLoc" Version="1.1.6" />
+    <PackageReference Include="Clowd.Squirrel" Version="2.8.40" />
     <PackageReference Include="Config.Net.Json" Version="4.14.23" />
     <PackageReference Include="Downloader" Version="2.2.8" />
     <PackageReference Include="Dragablz" Version="0.0.3.223" />
@@ -85,7 +87,6 @@
     <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
     <PackageReference Include="SharedMemory" Version="2.3.2" />
-    <PackageReference Include="squirrel.windows" Version="1.9.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
   </ItemGroup>


### PR DESCRIPTION
## Introduction

Old Squirrel was clunky and doesn't really support modern .NET. Also, recent wine-GE builds just don't install with old Squirrel. 

## Overview of changes in this PR

This PR will:  
- Remove the unused AssemblyInfo.cs
- Add a Assembly Manifest to indicate Squirrel Awareness (and lack of Windows 7 Compatibility)
- Update, fix warnings (and add nullability check because why not) for XIVLauncher/Updates.cs, including:
  - Adding unused `IAppTool` variable `t`, because the old overload has been obsoleted  
  - Pragma warning disable of the 'Please, PLEASE use ConfigureAwait()' warning, because adding `ConfigureAwait(true)` would be dumb
- Allow downloading of both Setup.exe and XIVLauncherSetup.exe during release creation, because Clowd.Squirrel will name it the latter way and I didn't bother renaming the file since I think that is actually a better name than just Setup.exe
- Create the release using Clowd.Squirrel, and with a pack folder that creates an updated .nuspec for goatsoft instead of goaaats

## Benefits of using Clowd.Squirrel

Changing to Clowd.Squirrel will give us the following benefits:
- Updater is a self-contained .NET 6 executable, and thus
- Allows installation of necessary .NET Framework versions
- Installs necessary Visual C++ Redistributable
- Runs on modern wine and doesn't break on Wine 7.1

## Breaking Changes

- Lutris Installer Script will need removal of the `/silent` argument, because installation of vcredist in silent mode will be cancelled
- In the same vein (but not really breaking), we can remove the vcredist installation in the Lutris Installer Script

## How to test

To facilitate testing, I have created three releases on the [my fork](https://github.com/dormanil/ffxivquicklauncher).  
Release 6.2.210 is identical to the 6.2.21 release here on goatcorp, apart from the change in update server.  
Release 6.2.211 has the upgrade to Clowd.Squirrel. Note that the size of the installer and the delta size is significantly bigger because of the size increase of the updater, and the lack of proper delta support when switching from squirrel.windows to Clowd.Squirrel.  
(Pre-)Release 6.2.215 is apart from the version difference identical to 6.2.211 and there for testing the Clowd.Squirrel -> Clowd.Squirrel update.