### PR TITLE
Fix viewport size with veldrid metal backend

### DIFF
--- a/src/XIVLauncher.Core/ImGuiHelpers.cs
+++ b/src/XIVLauncher.Core/ImGuiHelpers.cs
@@ -5,7 +5,7 @@ namespace XIVLauncher.Core;
 
 public static class ImGuiHelpers
 {
-    public static Vector2 ViewportSize => ImGui.GetMainViewport().Size;
+    public static Vector2 ViewportSize => ImGui.GetIO().DisplaySize;
 
     public static float GlobalScale => ImGui.GetIO().FontGlobalScale;
 


### PR DESCRIPTION
Unless when using Multi-Viewport `ImGui.GetIO().DisplaySize` and  `ImGui.GetMainViewport().Size` should be equivalent, however somehow the Metal backend is broken when using the latter (maybe related to HiDPI however the reported size seems to be around 30-40% of the real one so not entirely sure)