### PR TITLE
Local User Config Folder

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -26,12 +26,12 @@ public class CompatibilityTools
 
     public bool IsToolDownloaded => File.Exists(Wine64Path) && this.Prefix.Exists;
 
-    public CompatibilityTools(Storage storage)
+    public CompatibilityTools(Storage storage, DirectoryInfo configDirectory)
     {
         var toolsFolder = storage.GetFolder("compatibilitytool");
 
         this.toolDirectory = new DirectoryInfo(Path.Combine(toolsFolder.FullName, "beta"));
-        this.gameConfigDirectory = new DirectoryInfo(storage.GetFolder("ffxivConfig").FullName);
+        this.gameConfigDirectory = configDirectory;
         this.Prefix = storage.GetFolder("wineprefix");
         this.DotnetRuntime = storage.GetFolder("runtime");
 

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -12,6 +12,7 @@ namespace XIVLauncher.Common.Unix.Compatibility;
 public class CompatibilityTools
 {
     private DirectoryInfo toolDirectory;
+    private DirectoryInfo gameConfigDirectory;
 
     private const string WINE_GE_RELEASE_URL = "https://github.com/GloriousEggroll/wine-ge-custom/releases/download/GE-Proton7-8/wine-lutris-GE-Proton7-8-x86_64.tar.xz";
     private const string WINE_GE_RELEASE_NAME = "lutris-GE-Proton7-8-x86_64";
@@ -30,6 +31,7 @@ public class CompatibilityTools
         var toolsFolder = storage.GetFolder("compatibilitytool");
 
         this.toolDirectory = new DirectoryInfo(Path.Combine(toolsFolder.FullName, "beta"));
+        this.gameConfigDirectory = new DirectoryInfo(storage.GetFolder("ffxivConfig").FullName);
         this.Prefix = storage.GetFolder("wineprefix");
         this.DotnetRuntime = storage.GetFolder("runtime");
 
@@ -133,6 +135,6 @@ public class CompatibilityTools
     public void EnsureGameFixes()
     {
         EnsurePrefix();
-        GameFixes.AddDefaultConfig(this.Prefix);
+        GameFixes.AddDefaultConfig(gameConfigDirectory);
     }
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/GameFixes.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/GameFixes.cs
@@ -7,6 +7,9 @@ public static class GameFixes
 {
     public static void AddDefaultConfig(DirectoryInfo configFolder)
     {
+        if (!configFolder.Exists)
+            configFolder.Create();
+
         var gameConf = Path.Combine(configFolder.FullName, "FFXIV.cfg");
         if (!File.Exists(gameConf))
             File.WriteAllText(gameConf, "<FINAL FANTASY XIV Config File>\n\n<Cutscene Settings>\nCutsceneMovieOpening 1");

--- a/src/XIVLauncher.Common.Unix/Compatibility/GameFixes.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/GameFixes.cs
@@ -5,24 +5,13 @@ namespace XIVLauncher.Common.Unix.Compatibility;
 
 public static class GameFixes
 {
-    public static void AddDefaultConfig(DirectoryInfo prefix)
+    public static void AddDefaultConfig(DirectoryInfo configFolder)
     {
-        var usersDir = new DirectoryInfo(Path.Combine(prefix.FullName, "drive_c", "users"));
-        var thisUser = usersDir.GetDirectories().First(x => x.Name != "Public");
-
-        var myGames = new DirectoryInfo(Path.Combine(thisUser.FullName, "Documents", "My Games"));
-        if (!myGames.Exists)
-            myGames.Create();
-
-        var ffxiv = new DirectoryInfo(Path.Combine(myGames.FullName, "FINAL FANTASY XIV - A Realm Reborn"));
-        if (!ffxiv.Exists)
-            ffxiv.Create();
-
-        var gameConf = Path.Combine(ffxiv.FullName, "FFXIV.cfg");
+        var gameConf = Path.Combine(configFolder.FullName, "FFXIV.cfg");
         if (!File.Exists(gameConf))
             File.WriteAllText(gameConf, "<FINAL FANTASY XIV Config File>\n\n<Cutscene Settings>\nCutsceneMovieOpening 1");
 
-        var bootConf = Path.Combine(ffxiv.FullName, "FFXIV_BOOT.cfg");
+        var bootConf = Path.Combine(configFolder.FullName, "FFXIV_BOOT.cfg");
         if (!File.Exists(bootConf))
             File.WriteAllText(bootConf, "<FINAL FANTASY XIV Boot Config File>\n\n<Version>\nBrowser 1\nStartupCompleted 1");
     }

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -698,7 +698,7 @@ public class MainPage : Page
             throw new NotImplementedException();
         }
 
-        App.Settings.AdditionalArgs = $"UserPath=Z:{App.Settings.GameConfigPath.FullName.Replace("/", "\\")}";
+        App.Settings.AdditionalArgs = $"UserPath={Program.CompatibilityTools.UnixToWinePath(App.Settings.GameConfigPath.FullName)}";
 
         // We won't do any sanity checks here anymore, since that should be handled in StartLogin
         var launched = App.Launcher.LaunchGame(runner,

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -692,14 +692,14 @@ public class MainPage : Page
             var wineLogFile = new FileInfo(Path.Combine(App.Storage.GetFolder("logs").FullName, "wine.log"));
             runner = new UnixGameRunner(App.Settings.WineStartupType ?? WineStartupType.Command, App.Settings.WineStartCommandLine, Program.CompatibilityTools, App.Settings.DxvkHudType,
                 App.Settings.WineDebugVars ?? string.Empty, wineLogFile, dalamudLauncher, dalamudOk);
+
+            App.Settings.AdditionalArgs += $" UserPath={Program.CompatibilityTools.UnixToWinePath(App.Settings.GameConfigPath.FullName)}";
+            App.Settings.AdditionalArgs = App.Settings.AdditionalArgs.Trim();
         }
         else
         {
             throw new NotImplementedException();
         }
-
-        App.Settings.AdditionalArgs += $" UserPath={Program.CompatibilityTools.UnixToWinePath(App.Settings.GameConfigPath.FullName)}";
-        App.Settings.AdditionalArgs = App.Settings.AdditionalArgs.Trim();
 
         // We won't do any sanity checks here anymore, since that should be handled in StartLogin
         var launched = App.Launcher.LaunchGame(runner,

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -698,6 +698,8 @@ public class MainPage : Page
             throw new NotImplementedException();
         }
 
+        App.Settings.AdditionalArgs = $"UserPath=Z:{App.Settings.GameConfigPath.FullName.Replace("/", "\\")}";
+
         // We won't do any sanity checks here anymore, since that should be handled in StartLogin
         var launched = App.Launcher.LaunchGame(runner,
             loginResult.UniqueId,

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -654,6 +654,8 @@ public class MainPage : Page
 
         IGameRunner runner;
 
+        var gameArgs = App.Settings.AdditionalArgs ?? string.Empty;
+
         if (Environment.OSVersion.Platform == PlatformID.Win32NT)
         {
             runner = new WindowsGameRunner(dalamudLauncher, dalamudOk, App.Settings.DalamudLoadMethod.GetValueOrDefault(DalamudLoadMethod.DllInject));
@@ -693,8 +695,8 @@ public class MainPage : Page
             runner = new UnixGameRunner(App.Settings.WineStartupType ?? WineStartupType.Command, App.Settings.WineStartCommandLine, Program.CompatibilityTools, App.Settings.DxvkHudType,
                 App.Settings.WineDebugVars ?? string.Empty, wineLogFile, dalamudLauncher, dalamudOk);
 
-            App.Settings.AdditionalArgs += $" UserPath={Program.CompatibilityTools.UnixToWinePath(App.Settings.GameConfigPath.FullName)}";
-            App.Settings.AdditionalArgs = App.Settings.AdditionalArgs.Trim();
+            gameArgs += $" UserPath={Program.CompatibilityTools.UnixToWinePath(App.Settings.GameConfigPath.FullName)}";
+            gameArgs = gameArgs.Trim();
         }
         else
         {
@@ -707,7 +709,7 @@ public class MainPage : Page
             loginResult.OauthLogin.Region,
             loginResult.OauthLogin.MaxExpansion,
             isSteam,
-            App.Settings.AdditionalArgs,
+            gameArgs,
             App.Settings.GamePath,
             App.Settings.IsDx11 ?? true,
             App.Settings.ClientLanguage.GetValueOrDefault(ClientLanguage.English),

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -698,7 +698,8 @@ public class MainPage : Page
             throw new NotImplementedException();
         }
 
-        App.Settings.AdditionalArgs = $"UserPath={Program.CompatibilityTools.UnixToWinePath(App.Settings.GameConfigPath.FullName)}";
+        App.Settings.AdditionalArgs += $" UserPath={Program.CompatibilityTools.UnixToWinePath(App.Settings.GameConfigPath.FullName)}";
+        App.Settings.AdditionalArgs = App.Settings.AdditionalArgs.Trim();
 
         // We won't do any sanity checks here anymore, since that should be handled in StartLogin
         var launched = App.Launcher.LaunchGame(runner,

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -20,6 +20,11 @@ public class SettingsTabGame : SettingsTab
             }
         },
 
+        new SettingsEntry<DirectoryInfo>("Game Config Path", "Where the user config files will be stored.", () => Program.Config.GameConfigPath, x => Program.Config.GameConfigPath = x)
+        {
+            CheckValidity = x => string.IsNullOrWhiteSpace(x?.FullName) ? "Game Config Path is not set." : null
+        },
+
         new SettingsEntry<bool>("Use DirectX11", "Use the modern DirectX11 version of the game.", () => Program.Config.IsDx11 ?? true, x => Program.Config.IsDx11 = x)
         {
             CheckWarning = x => !x ? "DirectX 9 is no longer supported by Square Enix or Dalamud. Things may not work." : null

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabGame.cs
@@ -22,7 +22,10 @@ public class SettingsTabGame : SettingsTab
 
         new SettingsEntry<DirectoryInfo>("Game Config Path", "Where the user config files will be stored.", () => Program.Config.GameConfigPath, x => Program.Config.GameConfigPath = x)
         {
-            CheckValidity = x => string.IsNullOrWhiteSpace(x?.FullName) ? "Game Config Path is not set." : null
+            CheckValidity = x => string.IsNullOrWhiteSpace(x?.FullName) ? "Game Config Path is not set." : null,
+
+            // TODO: We should also support this on Windows
+            CheckVisibility = () => Environment.OSVersion.Platform == PlatformID.Unix,
         },
 
         new SettingsEntry<bool>("Use DirectX11", "Use the modern DirectX11 version of the game.", () => Program.Config.IsDx11 ?? true, x => Program.Config.IsDx11 = x)

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -16,6 +16,8 @@ public interface ILauncherConfig
 
     public DirectoryInfo? GamePath { get; set; }
 
+    public DirectoryInfo? GameConfigPath { get; set; }
+
     public string? AdditionalArgs { get; set; }
 
     public ClientLanguage? ClientLanguage { get; set; }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -84,6 +84,7 @@ class Program
         }
 
         Config.GamePath ??= storage.GetFolder("ffxiv");
+        Config.GameConfigPath ??= storage.GetFolder("ffxivConfig");
         Config.ClientLanguage ??= ClientLanguage.English;
         Config.DpiAwareness ??= DpiAwareness.Unaware;
         Config.IsAutologin ??= false;

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -142,7 +142,7 @@ class Program
         };
         DalamudUpdater.Run();
 
-        CompatibilityTools = new CompatibilityTools(storage);
+        CompatibilityTools = new CompatibilityTools(storage, Config.GameConfigPath);
 
         Log.Debug("Creating veldrid devices...");
 


### PR DESCRIPTION
Refactored the config folder to be localized to a static folder instead of within the prefix.

- Has a configuration option for user-defined folder (defaults to `ffxivConfig`)
- Uses an FFXIV launch argument to define the configuration folder from the Wine Z:\\.