### PR TITLE
Use HTTPS for xivapi.com

### DIFF
--- a/src/XIVLauncher.Core/Accounts/XivAccount.cs
+++ b/src/XIVLauncher.Core/Accounts/XivAccount.cs
@@ -93,7 +93,7 @@ public class XivAccount
         }
     }
 
-    private const string URL = "http://xivapi.com/";
+    private const string URL = "https://xivapi.com/";
 
     public static async Task<JObject> GetCharacterSearch(string name, string world)
     {

--- a/src/XIVLauncher.Core/Configuration/Accounts/XivAccount.cs
+++ b/src/XIVLauncher.Core/Configuration/Accounts/XivAccount.cs
@@ -100,7 +100,7 @@ public class XivAccount
         }
     }
 
-    private const string XIVAPI_BASE = "http://xivapi.com/";
+    private const string XIVAPI_BASE = "https://xivapi.com/";
 
     public static async Task<JObject> GetCharacterSearch(string name, string world)
     {

--- a/src/XIVLauncher/Accounts/XivAccount.cs
+++ b/src/XIVLauncher/Accounts/XivAccount.cs
@@ -94,7 +94,7 @@ namespace XIVLauncher.Accounts
             }
         }
 
-        private const string URL = "http://xivapi.com/";
+        private const string URL = "https://xivapi.com/";
 
         public static async Task<JObject> GetCharacterSearch(string name, string world)
         {


### PR DESCRIPTION
The xivapi docs [1] recommend using HTTPS to access the api.

 [1] https://xivapi.com/docs