### PR TITLE
Update to Configuration Storage

### DIFF
--- a/src/XIVLauncher.Core/ConfigStorage.cs
+++ b/src/XIVLauncher.Core/ConfigStorage.cs
@@ -1,0 +1,81 @@
+namespace XIVLauncher.Core;
+
+public class ConfigStorage
+{
+    public DirectoryInfo XLConfigRoot { get; }
+    public DirectoryInfo GameConfigRoot { get; }
+
+    private readonly DirectoryInfo legacyXLConfigRoot;
+    private readonly DirectoryInfo legacyGameConfigRoot;
+    private readonly DirectoryInfo symlinkGameConfigs;
+    
+    public ConfigStorage(string appName, string configFolder)
+    {
+        // https://developers.redhat.com/blog/2018/11/07/dotnet-special-folder-api-linux
+        // Support for migrating old configs, to bring storage inline with Windows
+        this.legacyXLConfigRoot = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".{appName}"));
+        this.legacyGameConfigRoot = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".{appName}/ffxivConfig"));
+
+        this.XLConfigRoot = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "XIVLauncher"));
+        this.GameConfigRoot = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "XIVLauncher"));
+        this.symlinkGameConfigs = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Documents/My Games/FINAL FANTASY XIV - A Realm Reborn"));
+
+        if (Directory.Exists(this.symlinkGameConfigs.FullName) && (!Directory.Exists(this.GameConfigRoot.FullName)))
+        {
+            // Copy directory, as moving it may break other mappings to the location
+            Directory.CreateDirectory(this.GameConfigRoot.FullName);
+            File.Copy(this.symlinkGameConfigs.FullName + "/FFXIV.cfg", this.GameConfigRoot + "/FFXIV.cfg");
+            File.Copy(this.symlinkGameConfigs.FullName + "/FFXIV_BOOT.cfg", this.GameConfigRoot + "/FFXIV_BOOT.cfg");
+        }
+        else
+        {
+            if (Directory.Exists(legacyGameConfigRoot.FullName) && (!Directory.Exists(this.GameConfigRoot.FullName)))
+                Directory.Move(legacyXLConfigRoot.FullName, XLConfigRoot.FullName);
+        }
+
+        if (!this.GameConfigRoot.Exists)
+        {
+            this.GameConfigRoot.Create();
+        }
+    }
+
+    public FileInfo GetXLConfig(string fileName)
+    {
+        if (File.Exists(this.legacyXLConfigRoot.FullName + $"/{fileName}"))
+        {
+            File.Move(this.legacyXLConfigRoot.FullName + $"/{fileName}", this.XLConfigRoot + $"/{fileName}");
+        }
+
+        return new FileInfo(Path.Combine(this.XLConfigRoot.FullName, fileName));
+    }
+
+    public FileInfo GetGameConfig(string fileName)
+    {
+        if (File.Exists(this.legacyGameConfigRoot.FullName + $"/{fileName}"))
+        {
+            File.Move(this.legacyGameConfigRoot.FullName + $"/{fileName}", this.GameConfigRoot + $"/{fileName}");
+        }
+
+        return new FileInfo(Path.Combine(this.GameConfigRoot.FullName, fileName));
+    }
+
+    public DirectoryInfo GetXLConfigFolder(string folderName)
+    {
+        var folder = new DirectoryInfo(Path.Combine(this.XLConfigRoot.FullName, folderName));
+
+        if (!folder.Exists)
+            folder.Create();
+
+        return folder;
+    }
+
+    public DirectoryInfo GetGameConfigFolder(string folderName)
+    {
+        var folder = new DirectoryInfo(Path.Combine(this.GameConfigRoot.FullName, folderName));
+
+        if (!folder.Exists)
+            folder.Create();
+
+        return folder;
+    }
+}

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -40,9 +40,11 @@ class Program
 
     private static LauncherApp launcherApp;
     private static Storage storage;
+    private static ConfigStorage configStorage;
     public static DirectoryInfo DotnetRuntime => storage.GetFolder("runtime");
 
     private const string APP_NAME = "xlcore";
+    private const string CONFIG_FOLDER = "XIVLauncher";
 
     private static uint invalidationFrames = 0;
     private static Vector2 lastMousePosition;
@@ -74,7 +76,7 @@ class Program
     {
         Config = new ConfigurationBuilder<ILauncherConfig>()
                  .UseCommandLineArgs()
-                 .UseIniFile(storage.GetFile("launcher.ini").FullName)
+                 .UseIniFile(configStorage.GetXLConfig("launcher.ini").FullName)
                  .UseTypeParser(new DirectoryInfoParser())
                  .UseTypeParser(new AddonListParser())
                  .Build();
@@ -85,7 +87,7 @@ class Program
         }
 
         Config.GamePath ??= storage.GetFolder("ffxiv");
-        Config.GameConfigPath ??= storage.GetFolder("ffxivConfig");
+        Config.GameConfigPath ??= configStorage.GetGameConfigFolder("ffxivConfig");
         Config.ClientLanguage ??= ClientLanguage.English;
         Config.DpiAwareness ??= DpiAwareness.Unaware;
         Config.IsAutologin ??= false;
@@ -113,6 +115,7 @@ class Program
     private static void Main(string[] args)
     {
         storage = new Storage(APP_NAME);
+        configStorage = new ConfigStorage(APP_NAME, CONFIG_FOLDER);
         SetupLogging();
         LoadConfig(storage);
 


### PR DESCRIPTION
This is a direct modification to the changes by pull #908 , and as discussed in issue #918 .

- Introduce ConfigStorage, which brings defines configuration storage in line with the Roaming/XIVQuickLauncher folder on windows.
- Modification to the default FFXIV config folder location, with logic to attempt detection and usage of old configs to make moving less painful.
- Modification to the default dalamud.ini location

This pull is in response to my discussions with @rekyuu 
