### PR TITLE
Adjusted DebugVar default, set -all if emtpy 

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -26,7 +26,7 @@ public class WineSettings
     {
         this.StartupType = startupType ?? WineStartupType.Custom;
         this.CustomBinPath = customBinPath;
-        this.DebugVars = debugVars;
+        this.DebugVars = string.IsNullOrEmpty(debugVars) ? "-all" : debugVars;
         this.LogFile = logFile;
         this.Prefix = prefix;
     }

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -105,7 +105,7 @@ class Program
 
         Config.WineStartupType ??= WineStartupType.Managed;
         Config.WineBinaryPath ??= "/usr/bin";
-        Config.WineDebugVars = "-all";
+        Config.WineDebugVars = "";
     }
 
     public const int STEAM_APP_ID = 39210;


### PR DESCRIPTION
Rather than set `-all` as the default `WINEDEBUG`, which shows in the Settings, sets it in WineSettings if debugVars is empty.

This pull is in reference to #921