### PR TITLE
Fix crash writing to the wine log

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -182,9 +182,12 @@ public class CompatibilityTools
             {
                 logWriter.WriteLine(errLine.Data);
             }
-            catch (Exception ex) when (ex is ArgumentOutOfRangeException || ex is OverflowException)
+            catch (Exception ex) when (ex is ArgumentOutOfRangeException ||
+                                       ex is OverflowException ||
+                                       ex is IndexOutOfRangeException)
             {
                 // very long wine log lines get chopped off after a (seemingly) arbitrary limit resulting in strings that are not null terminated
+                logWriter.WriteLine("Error writing Wine log line:");
                 logWriter.WriteLine(ex.Message);
             }
         });

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -173,7 +173,21 @@ public class CompatibilityTools
 
         Process helperProcess = new();
         helperProcess.StartInfo = psi; 
-        helperProcess.ErrorDataReceived += new DataReceivedEventHandler((_, errLine) => logWriter.WriteLine(errLine.Data));
+        helperProcess.ErrorDataReceived += new DataReceivedEventHandler((_, errLine) =>
+        {
+            if (String.IsNullOrEmpty(errLine.Data))
+                return;
+
+            try
+            {
+                logWriter.WriteLine(errLine.Data);
+            }
+            catch (Exception ex) when (ex is ArgumentOutOfRangeException || ex is OverflowException)
+            {
+                // very long wine log lines get chopped off after a (seemingly) arbitrary limit resulting in strings that are not null terminated
+                logWriter.WriteLine(ex.Message);
+            }
+        });
 
         helperProcess.Start();
         helperProcess.BeginErrorReadLine();

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -110,7 +110,7 @@ class Program
 
         Config.WineStartupType ??= WineStartupType.Managed;
         Config.WineBinaryPath ??= "/usr/bin";
-        Config.WineDebugVars = "-all";
+        Config.WineDebugVars ??= "-all";
     }
 
     public const int STEAM_APP_ID = 39210;


### PR DESCRIPTION
* Handles the case where very long wine log lines get chopped off after a (seemingly) arbitrary limit resulting in strings that are not null terminated
* Made it so that the `WINEDEBUG` setting is not reset on every app launch (if that is intended)