### PR TITLE
Use `wine-xiv` and further wine fixes

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -17,15 +17,20 @@ public class WineSettings
     public WineStartupType StartupType { get; private set; }
     public string CustomBinPath { get; private set; }
 
+    public string EsyncOn { get; private set; }
+    public string FsyncOn { get; private set; }
+
     public string DebugVars { get; private set; }
     public FileInfo LogFile { get; private set; }
 
     public DirectoryInfo Prefix { get; private set; }
 
-    public WineSettings(WineStartupType? startupType, string customBinPath, string debugVars, FileInfo logFile, DirectoryInfo prefix)
+    public WineSettings(WineStartupType? startupType, string customBinPath, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
     {
         this.StartupType = startupType ?? WineStartupType.Custom;
         this.CustomBinPath = customBinPath;
+        this.EsyncOn = (esyncOn ?? false) ? "1" : "0";
+        this.FsyncOn = (fsyncOn ?? false) ? "1" : "0";
         this.DebugVars = debugVars;
         this.LogFile = logFile;
         this.Prefix = prefix;

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -355,6 +355,9 @@ public class MainPage : Page
             {
                 using var process = await StartGameAndAddon(loginResult, isSteam, action == LoginAction.GameNoDalamud).ConfigureAwait(false);
 
+                if (process is null)
+                    throw new Exception("Could not obtain Process Handle");
+
                 if (process.ExitCode != 0 && (App.Settings.TreatNonZeroExitCodeAsFailure ?? false))
                 {
                     throw new Exception("Game exited with non-zero exit code");
@@ -723,10 +726,11 @@ public class MainPage : Page
 
         // This is a Windows process handle on Windows, a Wine pid on Unix-like systems
         var gamePid = 0;
+        Process? process = null;
 
         if (Environment.OSVersion.Platform == PlatformID.Win32NT)
         {
-            var process = launched as Process;
+            process = launched as Process;
             gamePid = process!.Id;
         }
         else if (Environment.OSVersion.Platform == PlatformID.Unix)
@@ -766,20 +770,25 @@ public class MainPage : Page
 
         if (Environment.OSVersion.Platform == PlatformID.Win32NT)
         {
-            var process = launched as Process;
             await Task.Run(() => process!.WaitForExit()).ConfigureAwait(false);
         }
         else if (Environment.OSVersion.Platform == PlatformID.Unix)
         {
-            Int32 processId = (int)launched;
-            while (Program.CompatibilityTools.GetProcessIds("ffxiv_dx11.exe").Contains(processId))
+            Int32 unixPid = Program.CompatibilityTools.GetUnixProcessId(gamePid);
+            if (unixPid == 0)
             {
-                Thread.Sleep(5000);
+                Log.Error("Could not retrive Unix process ID, this feature currently requires a patched wine version");
+                while (Program.CompatibilityTools.GetProcessIds("ffxiv_dx11.exe").Contains(gamePid))
+                    Thread.Sleep(5000);
             }
-            UnixGameRunner.runningPids.Remove(processId);
+            else
+            {
+                process = Process.GetProcessById(unixPid);
+                var handle = process.Handle;
+                await Task.Run(() => process!.WaitForExit()).ConfigureAwait(false);
+            }
+            UnixGameRunner.runningPids.Remove(gamePid);
         }
-        // TODO(Linux/macOS):  Translating the Wine pid to a Unix one requires talking to wineserver via Winelib
-        //                     and a platform specific binary with headers compatible with the wine version being shipped 
         else
         {
             Environment.Exit(0);
@@ -803,7 +812,7 @@ public class MainPage : Page
             Log.Error(ex, "Could not shut down Steam");
         }
 
-        return Process.GetProcessById(gamePid);
+        return process!;
     }
 
     private void PersistAccount(string username, string password, bool isOtp, bool isSteam)

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -258,9 +258,8 @@ class Program
     {
         var wineLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "wine.log"));
         var winePrefix = storage.GetFolder("wineprefix");
-        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix);
+        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
         var toolsFolder = storage.GetFolder("compatibilitytool");
-        CompatibilityTools = new CompatibilityTools(wineSettings, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, Config.ESyncEnabled, Config.FSyncEnabled, 
-            toolsFolder);
+        CompatibilityTools = new CompatibilityTools(wineSettings, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, toolsFolder);
     }
 }


### PR DESCRIPTION
This makes use of the extended `windbg` functionality of `wine-xiv` to obtain a unix process handle and check the games exit code similarly to how it is done on Windows currently.
Additionally this fixes DXVK dlls not being present when recreating the Wine prefix and fixes https://github.com/goatcorp/FFXIVQuickLauncher/issues/931.
When building for a specific Linux distro, the correct wine release can be chosen by using `dotnet build /p:DefineConstants=WINE_XIV_FEDORA_LINUX` for example with Ubuntu being used as default currently.