### PR TITLE
Confirm region on game installation path change

### DIFF
--- a/src/XIVLauncher.Common/Util.cs
+++ b/src/XIVLauncher.Common/Util.cs
@@ -39,6 +39,14 @@ namespace XIVLauncher.Common
             return Directory.Exists(Path.Combine(path, "game")) && Directory.Exists(Path.Combine(path, "boot"));
         }
 
+        public static bool CanFfxivMightNotBeInternationalClient(string path) {
+            if (Directory.Exists(Path.Combine(path, "sdo")))
+                return true;
+            if (File.Exists(Path.Combine(path, "boot", "FFXIV_Boot.exe")))
+                return true;
+            return false;
+        }
+
         public static bool LetChoosePath(string path)
         {
             if (string.IsNullOrEmpty(path))

--- a/src/XIVLauncher/Support/Troubleshooting.cs
+++ b/src/XIVLauncher/Support/Troubleshooting.cs
@@ -66,7 +66,8 @@ namespace XIVLauncher.Support
 
                     integrity = result.compareResult switch
                     {
-                        IntegrityCheck.CompareResult.NoServer => TroubleshootingPayload.IndexIntegrityResult.NoServer,
+                        IntegrityCheck.CompareResult.ReferenceFetchFailure => TroubleshootingPayload.IndexIntegrityResult.ReferenceFetchFailure,
+                        IntegrityCheck.CompareResult.ReferenceNotFound => TroubleshootingPayload.IndexIntegrityResult.ReferenceNotFound,
                         IntegrityCheck.CompareResult.Invalid => TroubleshootingPayload.IndexIntegrityResult.Failed,
                         _ => integrity
                     };
@@ -188,7 +189,8 @@ namespace XIVLauncher.Support
                 Failed,
                 Exception,
                 NoGame,
-                NoServer,
+                ReferenceNotFound,
+                ReferenceFetchFailure,
                 Success,
             }
 

--- a/src/XIVLauncher/Windows/FirstTimeSetupWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/FirstTimeSetupWindow.xaml.cs
@@ -89,8 +89,20 @@ namespace XIVLauncher.Windows
 
                 if (!Util.IsValidFfxivPath(GamePathEntry.Text))
                 {
-                    CustomMessageBox.Show(Loc.Localize("GamePathInvalidError", "The folder you selected has no FFXIV installation.\nXIVLauncher will install FFXIV the first time you log in."), "XIVLauncher",
-                        MessageBoxButton.OK, MessageBoxImage.Information, parentWindow: this);
+                    if (CustomMessageBox.Show(Loc.Localize("GamePathInvalidConfirm", "The folder you selected has no FFXIV installation.\nXIVLauncher will install FFXIV the first time you log in.\nContinue?"), "XIVLauncher",
+                        MessageBoxButton.YesNo, MessageBoxImage.Information, parentWindow: this) != MessageBoxResult.Yes)
+                    {
+                        return;
+                    }
+                }
+
+                if (Util.CanFfxivMightNotBeInternationalClient(GamePathEntry.Text))
+                {
+                    if (CustomMessageBox.Show(Loc.Localize("GamePathRegionConfirm", "The folder you selected might be the Chinese or Korean release of the game. XIVLauncher only supports international release of the game.\nIs the folder you've selected indeed for the international version?"), "XIVLauncher",
+                        MessageBoxButton.YesNo, MessageBoxImage.Warning, parentWindow: this) != MessageBoxResult.Yes)
+                    {
+                        return;
+                    }
                 }
             }
 

--- a/src/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -280,10 +280,16 @@ namespace XIVLauncher.Windows
                 {
                     switch (task.Result.compareResult)
                     {
-                        case IntegrityCheck.CompareResult.NoServer:
+                        case IntegrityCheck.CompareResult.ReferenceNotFound:
                             CustomMessageBox.Show(Loc.Localize("IntegrityCheckImpossible",
                                     "There is no reference report yet for this game version. Please try again later."),
                                 "XIVLauncher", MessageBoxButton.OK, MessageBoxImage.Asterisk, parentWindow: Window.GetWindow(this));
+                            return;
+
+                        case IntegrityCheck.CompareResult.ReferenceFetchFailure:
+                            CustomMessageBox.Show(Loc.Localize("IntegrityCheckNetworkError",
+                                    "Failed to download reference files for checking integrity. Check your internet connection and try again."),
+                                "XIVLauncher", MessageBoxButton.OK, MessageBoxImage.Error, parentWindow: Window.GetWindow(this));
                             return;
 
                         case IntegrityCheck.CompareResult.Invalid:

--- a/src/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -503,17 +503,32 @@ namespace XIVLauncher.Windows
 
         private void GamePathEntry_OnTextChanged(object sender, TextChangedEventArgs e)
         {
-            var isLetChoose = false;
+            var isBootOrGame = false;
+            var mightBeNonInternationalVersion = false;
             try
             {
-                isLetChoose = Util.LetChoosePath(ViewModel.GamePath);
+                isBootOrGame = !Util.LetChoosePath(ViewModel.GamePath);
+                mightBeNonInternationalVersion = Util.CanFfxivMightNotBeInternationalClient(ViewModel.GamePath);
             }
             catch (Exception ex)
             {
                 Log.Error(ex, "Could not check game path");
             }
 
-            GamePathSafeguardText.Visibility = !isLetChoose ? Visibility.Visible : Visibility.Collapsed;
+            if (isBootOrGame)
+            {
+                GamePathSafeguardText.Text = ViewModel.GamePathSafeguardLoc;
+                GamePathSafeguardText.Visibility = Visibility.Visible;
+            }
+            else if (mightBeNonInternationalVersion)
+            {
+                GamePathSafeguardText.Text = ViewModel.GamePathSafeguardRegionLoc;
+                GamePathSafeguardText.Visibility = Visibility.Visible;
+            }
+            else
+            {
+                GamePathSafeguardText.Visibility = Visibility.Collapsed;
+            }
         }
 
         private void LicenseText_OnMouseUp(object sender, MouseButtonEventArgs e)

--- a/src/XIVLauncher/Windows/ViewModel/SettingsControlViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/SettingsControlViewModel.cs
@@ -65,6 +65,8 @@ namespace XIVLauncher.Windows.ViewModel
                 "Please select the folder your game is installed in.\r\nIt should contain the folders \"game\" and \"boot\".");
             GamePathSafeguardLoc = Loc.Localize("GamePathSafeguardError",
                 "Please do not select the \"game\" or \"boot\" folder of your FFXIV installation, and choose the folder that contains these instead.");
+            GamePathSafeguardRegionLoc = Loc.Localize("GamePathSafeguardRegionWarning",
+                "XIVLauncher does not support Chinese or Korean version of the game. Make sure this path indeed is for the international version.");
             SteamCheckBoxLoc = Loc.Localize("FirstTimeSteamCheckBox", "Enable Steam integration");
             OtpServerCheckBoxLoc = Loc.Localize("OtpServerCheckBox", "Enable XL Authenticator app/OTP macro support");
             AdditionalArgumentsLoc = Loc.Localize("AdditionalArguments", "Additional launch arguments");
@@ -166,6 +168,7 @@ namespace XIVLauncher.Windows.ViewModel
         public string SettingsGameLoc { get; private set; }
         public string GamePathLoc { get; private set; }
         public string GamePathSafeguardLoc { get; private set; }
+        public string GamePathSafeguardRegionLoc { get; private set; }
         public string SteamCheckBoxLoc { get; private set; }
         public string OtpServerCheckBoxLoc { get; private set; }
         public string AdditionalArgumentsLoc { get; private set; }


### PR DESCRIPTION
This will check whether `sdo` folder or `boot/FFXIV_Boot.exe` file exists and warn the user accordingly.

Additionally, index integrity check result has been divided from NoServer to ReferenceNotFound and ReferenceFetchFailure.