### PR TITLE
refactor: abstract out Launcher > ILauncher/SqexLauncher

### DIFF
--- a/src/XIVLauncher.Common/Game/Exceptions/VersionCheckLoginException.cs
+++ b/src/XIVLauncher.Common/Game/Exceptions/VersionCheckLoginException.cs
@@ -1,0 +1,14 @@
+using System;
+
+namespace XIVLauncher.Common.Game.Exceptions;
+
+public class VersionCheckLoginException : Exception
+{
+    public LoginState State { get; }
+
+    public VersionCheckLoginException(LoginState state)
+        : base()
+    {
+        State = state;
+    }
+}

--- a/src/XIVLauncher.Common/Game/Headlines.cs
+++ b/src/XIVLauncher.Common/Game/Headlines.cs
@@ -4,6 +4,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Converters;
+using XIVLauncher.Common.Game.Launcher;
 
 namespace XIVLauncher.Common.Game
 {
@@ -51,7 +52,7 @@ namespace XIVLauncher.Common.Game
 
     public partial class Headlines
     {
-        public static async Task<Headlines> Get(Launcher game, ClientLanguage language)
+        public static async Task<Headlines> Get(ILauncher game, ClientLanguage language)
         {
             var unixTimestamp = Util.GetUnixMillis();
             var langCode = language.GetLangCode();

--- a/src/XIVLauncher.Common/Game/Launcher/ActozLauncher.cs
+++ b/src/XIVLauncher.Common/Game/Launcher/ActozLauncher.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+
+#if NET6_0_OR_GREATER && !WIN32
+using System.Net.Security;
+#endif
+
+using System.Threading.Tasks;
+using Serilog;
+using XIVLauncher.Common.Game.Patch.PatchList;
+using XIVLauncher.Common.PlatformAbstractions;
+
+#nullable enable
+
+namespace XIVLauncher.Common.Game.Launcher;
+
+public class ActozLauncher : ILauncher
+{
+    private readonly ISettings settings;
+    private readonly HttpClient client;
+
+    public ActozLauncher(ISettings settings)
+    {
+        this.settings = settings;
+
+        ServicePointManager.Expect100Continue = false;
+
+#if NET6_0_OR_GREATER && !WIN32
+        var sslOptions = new SslClientAuthenticationOptions()
+        {
+            CipherSuitesPolicy = new CipherSuitesPolicy(new[] { TlsCipherSuite.TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 })
+        };
+
+        var handler = new SocketsHttpHandler
+        {
+            UseCookies = false,
+            SslOptions = sslOptions,
+        };
+#else
+        var handler = new HttpClientHandler
+        {
+            UseCookies = false,
+        };
+#endif
+
+        this.client = new HttpClient(handler);
+    }
+
+    // TODO(Ava): not 100% sure this is correct, don't quote me on it
+    private const string PATCHER_USER_AGENT = "FFXIV_Patch";
+    private const int CURRENT_EXPANSION_LEVEL = 4;
+
+    public async Task<LoginResult> Login(string userName, string password, string otp, bool isSteam, bool useCache, DirectoryInfo gamePath, bool forceBaseVersion, bool isFreeTrial)
+    {
+        throw new NotImplementedException();
+    }
+
+    public object? LaunchGame(IGameRunner runner, string sessionId, int region, int expansionLevel,
+                              bool isSteamServiceAccount, string additionalArguments,
+                              DirectoryInfo gamePath, bool isDx11, ClientLanguage language,
+                              bool encryptArguments, DpiAwareness dpiAwareness)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<PatchListEntry[]> CheckBootVersion(DirectoryInfo gamePath, bool forceBaseVersion = false)
+    {
+        return Array.Empty<PatchListEntry>();
+    }
+
+    public async Task<PatchListEntry[]> CheckGameVersion(DirectoryInfo gamePath, bool forceBaseVersion = false)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get,
+            $"http://gamever-live.ff14.co.kr/http/win32/actoz_release_ko_game/{(forceBaseVersion ? Constants.BASE_GAME_VERSION : Repository.Ffxiv.GetVer(gamePath))}/");
+
+        request.Headers.AddWithoutValidation("X-Hash-Check", "enabled");
+        request.Headers.AddWithoutValidation("User-Agent", PATCHER_USER_AGENT);
+
+        Util.EnsureVersionSanity(gamePath, CURRENT_EXPANSION_LEVEL);
+
+        var resp = await this.client.SendAsync(request);
+        var text = await resp.Content.ReadAsStringAsync();
+
+        if (string.IsNullOrEmpty(text))
+            return Array.Empty<PatchListEntry>();
+
+        Log.Verbose("Game Patching is needed... List:\n{PatchList}", text);
+
+        return PatchListParser.Parse(text);
+    }
+
+    public async Task<string> GenPatchToken(string patchUrl, string uniqueId)
+    {
+        // KR/CN don't require authentication for patches
+        return patchUrl;
+    }
+
+    public async Task<GateStatus> GetGateStatus(ClientLanguage language)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<bool> GetLoginStatus()
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<byte[]> DownloadAsLauncher(string url, ClientLanguage language, string contentType = "")
+    {
+        throw new NotImplementedException();
+    }
+}
+
+#nullable restore

--- a/src/XIVLauncher.Common/Game/Launcher/ILauncher.cs
+++ b/src/XIVLauncher.Common/Game/Launcher/ILauncher.cs
@@ -1,0 +1,30 @@
+using System.IO;
+using System.Threading.Tasks;
+using XIVLauncher.Common.Game.Patch.PatchList;
+using XIVLauncher.Common.PlatformAbstractions;
+
+namespace XIVLauncher.Common.Game.Launcher;
+
+public interface ILauncher
+{
+    public Task<PatchListEntry[]> CheckBootVersion(DirectoryInfo gamePath, bool forceBaseVersion = false);
+
+    public Task<PatchListEntry[]> CheckGameVersion(DirectoryInfo gamePath, bool forceBaseVersion = false);
+
+    // TODO(Ava): KR/CN probably don't need isSteam or isFreeTrial, figure out how to abstract this better
+    public Task<LoginResult> Login(string userName, string password, string otp, bool isSteam, bool useCache, DirectoryInfo gamePath, bool forceBaseVersion, bool isFreeTrial);
+
+    // TODO(Ava): same as above for isSteamServiceAccount
+    public object? LaunchGame(IGameRunner runner, string sessionId, int region, int expansionLevel,
+                              bool isSteamServiceAccount, string additionalArguments,
+                              DirectoryInfo gamePath, bool isDx11, ClientLanguage language,
+                              bool encryptArguments, DpiAwareness dpiAwareness);
+
+    public Task<GateStatus> GetGateStatus(ClientLanguage language);
+
+    public Task<bool> GetLoginStatus();
+
+    public Task<string> GenPatchToken(string patchUrl, string uniqueId);
+
+    public Task<byte[]> DownloadAsLauncher(string url, ClientLanguage language, string contentType = "");
+}

--- a/src/XIVLauncher.Common/Game/Launcher/ShandaLauncher.cs
+++ b/src/XIVLauncher.Common/Game/Launcher/ShandaLauncher.cs
@@ -1,0 +1,116 @@
+using System;
+using System.IO;
+using System.Net;
+using System.Net.Http;
+
+#if NET6_0_OR_GREATER && !WIN32
+using System.Net.Security;
+#endif
+
+using System.Threading.Tasks;
+using Serilog;
+using XIVLauncher.Common.Game.Patch.PatchList;
+using XIVLauncher.Common.PlatformAbstractions;
+
+#nullable enable
+
+namespace XIVLauncher.Common.Game.Launcher;
+
+public class ShandaLauncher : ILauncher
+{
+    private readonly ISettings settings;
+    private readonly HttpClient client;
+
+    public ShandaLauncher(ISettings settings)
+    {
+        this.settings = settings;
+
+        ServicePointManager.Expect100Continue = false;
+
+#if NET6_0_OR_GREATER && !WIN32
+        var sslOptions = new SslClientAuthenticationOptions()
+        {
+            CipherSuitesPolicy = new CipherSuitesPolicy(new[] { TlsCipherSuite.TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 })
+        };
+
+        var handler = new SocketsHttpHandler
+        {
+            UseCookies = false,
+            SslOptions = sslOptions,
+        };
+#else
+        var handler = new HttpClientHandler
+        {
+            UseCookies = false,
+        };
+#endif
+
+        this.client = new HttpClient(handler);
+    }
+
+    // TODO(Ava): not 100% sure this is correct, don't quote me on it
+    private const string PATCHER_USER_AGENT = "FFXIV_Patch";
+    private const int CURRENT_EXPANSION_LEVEL = 4;
+
+    public async Task<LoginResult> Login(string userName, string password, string otp, bool isSteam, bool useCache, DirectoryInfo gamePath, bool forceBaseVersion, bool isFreeTrial)
+    {
+        throw new NotImplementedException();
+    }
+
+    public object? LaunchGame(IGameRunner runner, string sessionId, int region, int expansionLevel,
+                              bool isSteamServiceAccount, string additionalArguments,
+                              DirectoryInfo gamePath, bool isDx11, ClientLanguage language,
+                              bool encryptArguments, DpiAwareness dpiAwareness)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<PatchListEntry[]> CheckBootVersion(DirectoryInfo gamePath, bool forceBaseVersion = false)
+    {
+        return Array.Empty<PatchListEntry>();
+    }
+
+    public async Task<PatchListEntry[]> CheckGameVersion(DirectoryInfo gamePath, bool forceBaseVersion = false)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Get,
+            $"http://ffxivpatch01.ff14.sdo.com/http/win32/shanda_release_chs_game/{(forceBaseVersion ? Constants.BASE_GAME_VERSION : Repository.Ffxiv.GetVer(gamePath))}/");
+
+        request.Headers.AddWithoutValidation("X-Hash-Check", "enabled");
+        request.Headers.AddWithoutValidation("User-Agent", PATCHER_USER_AGENT);
+
+        Util.EnsureVersionSanity(gamePath, CURRENT_EXPANSION_LEVEL);
+
+        var resp = await this.client.SendAsync(request);
+        var text = await resp.Content.ReadAsStringAsync();
+
+        if (string.IsNullOrEmpty(text))
+            return Array.Empty<PatchListEntry>();
+
+        Log.Verbose("Game Patching is needed... List:\n{PatchList}", text);
+
+        return PatchListParser.Parse(text);
+    }
+
+    public async Task<string> GenPatchToken(string patchUrl, string uniqueId)
+    {
+        // KR/CN don't require authentication for patches
+        return patchUrl;
+    }
+
+    public async Task<GateStatus> GetGateStatus(ClientLanguage language)
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<bool> GetLoginStatus()
+    {
+        throw new NotImplementedException();
+    }
+
+    public async Task<byte[]> DownloadAsLauncher(string url, ClientLanguage language, string contentType = "")
+    {
+        throw new NotImplementedException();
+    }
+}
+
+#nullable restore

--- a/src/XIVLauncher.Common/Game/LoginResult.cs
+++ b/src/XIVLauncher.Common/Game/LoginResult.cs
@@ -1,0 +1,11 @@
+using XIVLauncher.Common.Game.Patch.PatchList;
+
+namespace XIVLauncher.Common.Game;
+
+public class LoginResult
+{
+    public LoginState State { get; set; }
+    public PatchListEntry[] PendingPatches { get; set; }
+    public OauthLoginResult OauthLogin { get; set; }
+    public string UniqueId { get; set; }
+}

--- a/src/XIVLauncher.Common/Game/LoginState.cs
+++ b/src/XIVLauncher.Common/Game/LoginState.cs
@@ -1,0 +1,12 @@
+namespace XIVLauncher.Common.Game;
+
+public enum LoginState
+{
+    Unknown,
+    Ok,
+    NeedsPatchGame,
+    NeedsPatchBoot,
+    NoService,
+    NoTerms,
+    NoLogin
+}

--- a/src/XIVLauncher.Common/Game/OauthLoginResult.cs
+++ b/src/XIVLauncher.Common/Game/OauthLoginResult.cs
@@ -1,0 +1,10 @@
+namespace XIVLauncher.Common.Game;
+
+public class OauthLoginResult
+{
+    public string SessionId { get; set; }
+    public int Region { get; set; }
+    public bool TermsAccepted { get; set; }
+    public bool Playable { get; set; }
+    public int MaxExpansion { get; set; }
+}

--- a/src/XIVLauncher.Common/Game/Patch/PatchManager.cs
+++ b/src/XIVLauncher.Common/Game/Patch/PatchManager.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Serilog;
+using XIVLauncher.Common.Game.Launcher;
 using XIVLauncher.Common.Game.Patch.Acquisition;
 using XIVLauncher.Common.Game.Patch.Acquisition.Aria;
 using XIVLauncher.Common.Game.Patch.PatchList;
@@ -41,7 +42,7 @@ namespace XIVLauncher.Common.Game.Patch
         private readonly DirectoryInfo gamePath;
         private readonly DirectoryInfo patchStore;
         private readonly PatchInstaller installer;
-        private readonly Launcher launcher;
+        private readonly ILauncher launcher;
         private readonly string sid;
 
         public readonly IReadOnlyList<PatchDownload> Downloads;
@@ -77,7 +78,7 @@ namespace XIVLauncher.Common.Game.Patch
             HashCheck,
         }
 
-        public PatchManager(AcquisitionMethod acquisitionMethod, long speedLimitBytes, Repository repo, IEnumerable<PatchListEntry> patches, DirectoryInfo gamePath, DirectoryInfo patchStore, PatchInstaller installer, Launcher launcher, string sid)
+        public PatchManager(AcquisitionMethod acquisitionMethod, long speedLimitBytes, Repository repo, IEnumerable<PatchListEntry> patches, DirectoryInfo gamePath, DirectoryInfo patchStore, PatchInstaller installer, ILauncher launcher, string sid)
         {
             Debug.Assert(patches != null, "patches != null ASSERTION FAILED");
 

--- a/src/XIVLauncher.Common/Game/Patch/PatchVerifier.cs
+++ b/src/XIVLauncher.Common/Game/Patch/PatchVerifier.cs
@@ -103,7 +103,7 @@ namespace XIVLauncher.Common.Game.Patch
 
         public VerifyState State { get; private set; } = VerifyState.NotStarted;
 
-        public PatchVerifier(ISettings settings, Launcher.LoginResult loginResult, int progressUpdateInterval, int maxExpansion)
+        public PatchVerifier(ISettings settings, LoginResult loginResult, int progressUpdateInterval, int maxExpansion)
         {
             this._settings = settings;
             _client = new HttpClient();
@@ -146,7 +146,7 @@ namespace XIVLauncher.Common.Game.Patch
             return _verificationTask ?? Task.CompletedTask;
         }
 
-        private void SetLoginState(Launcher.LoginResult result)
+        private void SetLoginState(LoginResult result)
         {
             _patchSources.Clear();
 

--- a/src/XIVLauncher.Common/Util.cs
+++ b/src/XIVLauncher.Common/Util.cs
@@ -8,6 +8,7 @@ using System.Net.Http.Headers;
 using System.Net.Sockets;
 using System.Runtime.InteropServices;
 using System.Text;
+using XIVLauncher.Common.Game.Exceptions;
 
 namespace XIVLauncher.Common
 {
@@ -39,7 +40,8 @@ namespace XIVLauncher.Common
             return Directory.Exists(Path.Combine(path, "game")) && Directory.Exists(Path.Combine(path, "boot"));
         }
 
-        public static bool CanFfxivMightNotBeInternationalClient(string path) {
+        public static bool CanFfxivMightNotBeInternationalClient(string path)
+        {
             if (Directory.Exists(Path.Combine(path, "sdo")))
                 return true;
             if (File.Exists(Path.Combine(path, "boot", "FFXIV_Boot.exe")))
@@ -351,6 +353,44 @@ namespace XIVLauncher.Common
 
             if (tarProcess.ExitCode != 0)
                 throw new Exception("Could not untar compatibility tool");
+        }
+
+        /// <summary>
+        /// Check ver & bck files for sanity.
+        /// </summary>
+        /// <param name="gamePath"></param>
+        /// <param name="exLevel"></param>
+        public static void EnsureVersionSanity(DirectoryInfo gamePath, int exLevel)
+        {
+            var failed = string.IsNullOrWhiteSpace(Repository.Ffxiv.GetVer(gamePath));
+            failed &= string.IsNullOrWhiteSpace(Repository.Ffxiv.GetVer(gamePath, true));
+
+            if (exLevel >= 1)
+            {
+                failed &= string.IsNullOrWhiteSpace(Repository.Ex1.GetVer(gamePath));
+                failed &= string.IsNullOrWhiteSpace(Repository.Ex1.GetVer(gamePath, true));
+            }
+
+            if (exLevel >= 2)
+            {
+                failed &= string.IsNullOrWhiteSpace(Repository.Ex2.GetVer(gamePath));
+                failed &= string.IsNullOrWhiteSpace(Repository.Ex2.GetVer(gamePath, true));
+            }
+
+            if (exLevel >= 3)
+            {
+                failed &= string.IsNullOrWhiteSpace(Repository.Ex3.GetVer(gamePath));
+                failed &= string.IsNullOrWhiteSpace(Repository.Ex3.GetVer(gamePath, true));
+            }
+
+            if (exLevel >= 4)
+            {
+                failed &= string.IsNullOrWhiteSpace(Repository.Ex4.GetVer(gamePath));
+                failed &= string.IsNullOrWhiteSpace(Repository.Ex4.GetVer(gamePath, true));
+            }
+
+            if (failed)
+                throw new InvalidVersionFilesException();
         }
     }
 }

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -162,7 +162,7 @@ public class MainPage : Page
             Environment.Exit(0);
     }
 
-    private async Task<Launcher.LoginResult> TryLoginToGame(string username, string password, string otp, bool isSteam, LoginAction action)
+    private async Task<LoginResult> TryLoginToGame(string username, string password, string otp, bool isSteam, LoginAction action)
     {
         bool? gateStatus = null;
 
@@ -228,9 +228,9 @@ public class MainPage : Page
         }
     }
 
-    private async Task<bool> TryProcessLoginResult(Launcher.LoginResult loginResult, bool isSteam, LoginAction action)
+    private async Task<bool> TryProcessLoginResult(LoginResult loginResult, bool isSteam, LoginAction action)
     {
-        if (loginResult.State == Launcher.LoginState.NoService)
+        if (loginResult.State == LoginState.NoService)
         {
             /*
             CustomMessageBox.Show(
@@ -245,7 +245,7 @@ public class MainPage : Page
             return false;
         }
 
-        if (loginResult.State == Launcher.LoginState.NoTerms)
+        if (loginResult.State == LoginState.NoTerms)
         {
             /*
             CustomMessageBox.Show(
@@ -271,7 +271,7 @@ public class MainPage : Page
          * In the future we may be able to just delete /boot and run boot patches again, but this doesn't happen often enough to warrant the
          * complexity and if boot is fucked game probably is too.
          */
-        if (loginResult.State == Launcher.LoginState.NeedsPatchBoot)
+        if (loginResult.State == LoginState.NeedsPatchBoot)
         {
             /*
             CustomMessageBox.Show(
@@ -289,12 +289,12 @@ public class MainPage : Page
         {
             try
             {
-                if (loginResult.State == Launcher.LoginState.NeedsPatchGame)
+                if (loginResult.State == LoginState.NeedsPatchGame)
                 {
                     if (!await RepairGame(loginResult).ConfigureAwait(false))
                         return false;
 
-                    loginResult.State = Launcher.LoginState.Ok;
+                    loginResult.State = LoginState.Ok;
                     action = LoginAction.Game;
                 }
                 else
@@ -324,7 +324,7 @@ public class MainPage : Page
             }
         }
 
-        if (loginResult.State == Launcher.LoginState.NeedsPatchGame)
+        if (loginResult.State == LoginState.NeedsPatchGame)
         {
             if (!await InstallGamePatch(loginResult).ConfigureAwait(false))
             {
@@ -332,7 +332,7 @@ public class MainPage : Page
                 return false;
             }
 
-            loginResult.State = Launcher.LoginState.Ok;
+            loginResult.State = LoginState.Ok;
             action = LoginAction.Game;
         }
 
@@ -345,7 +345,7 @@ public class MainPage : Page
             return false;
         }
 
-        Debug.Assert(loginResult.State == Launcher.LoginState.Ok);
+        Debug.Assert(loginResult.State == LoginState.Ok);
 
         while (true)
         {
@@ -576,7 +576,7 @@ public class MainPage : Page
         }
     }
 
-    public async Task<Process> StartGameAndAddon(Launcher.LoginResult loginResult, bool isSteam, bool forceNoDalamud)
+    public async Task<Process> StartGameAndAddon(LoginResult loginResult, bool isSteam, bool forceNoDalamud)
     {
         var dalamudOk = false;
 
@@ -870,7 +870,7 @@ public class MainPage : Page
                 return false;
             }
 
-            if (bootPatches == null)
+            if (bootPatches.Length == 0)
                 return true;
 
             return await TryHandlePatchAsync(Repository.Boot, bootPatches, null).ConfigureAwait(false);
@@ -884,10 +884,10 @@ public class MainPage : Page
         }
     }
 
-    private Task<bool> InstallGamePatch(Launcher.LoginResult loginResult)
+    private Task<bool> InstallGamePatch(LoginResult loginResult)
     {
-        Debug.Assert(loginResult.State == Launcher.LoginState.NeedsPatchGame,
-            "loginResult.State == Launcher.LoginState.NeedsPatchGame ASSERTION FAILED");
+        Debug.Assert(loginResult.State == LoginState.NeedsPatchGame,
+            "loginResult.State == LoginState.NeedsPatchGame ASSERTION FAILED");
 
         Debug.Assert(loginResult.PendingPatches != null, "loginResult.PendingPatches != null ASSERTION FAILED");
 
@@ -1055,7 +1055,7 @@ public class MainPage : Page
         Environment.Exit(0);
     }
 
-    private async Task<bool> RepairGame(Launcher.LoginResult loginResult)
+    private async Task<bool> RepairGame(LoginResult loginResult)
     {
         var doLogin = false;
         var mutex = new Mutex(false, "XivLauncherIsPatching");

--- a/src/XIVLauncher.Core/LauncherApp.cs
+++ b/src/XIVLauncher.Core/LauncherApp.cs
@@ -2,7 +2,7 @@
 using System.Numerics;
 using ImGuiNET;
 using XIVLauncher.Common;
-using XIVLauncher.Common.Game;
+using XIVLauncher.Common.Game.Launcher;
 using XIVLauncher.Common.PlatformAbstractions;
 using XIVLauncher.Core.Accounts;
 using XIVLauncher.Core.Components;
@@ -88,7 +88,7 @@ public class LauncherApp : Component
     };
 
     public ILauncherConfig Settings => Program.Config;
-    public Launcher Launcher { get; private set; }
+    public ILauncher Launcher { get; private set; }
     public ISteam Steam => Program.Steam;
     public Storage Storage { get; private set; }
 
@@ -109,7 +109,7 @@ public class LauncherApp : Component
 
         this.Accounts = new AccountManager(this.Storage.GetFile("accounts.json"));
         this.UniqueIdCache = new CommonUniqueIdCache(this.Storage.GetFile("uidCache.json"));
-        this.Launcher = new Launcher(Program.Steam, UniqueIdCache, Program.CommonSettings);
+        this.Launcher = new SqexLauncher(Program.Steam, UniqueIdCache, Program.CommonSettings);
 
         this.mainPage = new MainPage(this);
         this.setPage = new SettingsPage(this);

--- a/src/XIVLauncher/Windows/MainWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/MainWindow.xaml.cs
@@ -16,6 +16,7 @@ using XIVLauncher.Accounts;
 using XIVLauncher.Common;
 using XIVLauncher.Common.Dalamud;
 using XIVLauncher.Common.Game;
+using XIVLauncher.Common.Game.Launcher;
 using XIVLauncher.Common.Game.Patch.Acquisition;
 using XIVLauncher.Support;
 using XIVLauncher.Windows.ViewModel;
@@ -38,7 +39,7 @@ namespace XIVLauncher.Windows
         private AccountManager _accountManager;
 
         private MainWindowViewModel Model => this.DataContext as MainWindowViewModel;
-        private readonly Launcher _launcher;
+        private readonly ILauncher _launcher;
 
         public MainWindow()
         {
@@ -427,7 +428,7 @@ namespace XIVLauncher.Windows
 
             if (gateStatus || bootPatches != null)
             {
-                if (bootPatches != null)
+                if (bootPatches.Length > 0)
                 {
                     CustomMessageBox.Show(Loc.Localize("MaintenanceQueueBootPatch",
                         "A patch for the FFXIV launcher was detected.\nThis usually means that there is a patch for the game as well.\n\nYou will now be logged in."), "XIVLauncher", parentWindow: this);
@@ -519,9 +520,9 @@ namespace XIVLauncher.Windows
 
         private void FakeStart_OnClick(object sender, RoutedEventArgs e)
         {
-            _ = Model.StartGameAndAddon(new Launcher.LoginResult
+            _ = Model.StartGameAndAddon(new LoginResult
             {
-                OauthLogin = new Launcher.OauthLoginResult
+                OauthLogin = new OauthLoginResult
                 {
                     MaxExpansion = 4,
                     Playable = true,
@@ -529,7 +530,7 @@ namespace XIVLauncher.Windows
                     SessionId = "0",
                     TermsAccepted = true
                 },
-                State = Launcher.LoginState.Ok,
+                State = LoginState.Ok,
                 UniqueId = "0"
             }, false, false).ConfigureAwait(false);
         }


### PR DESCRIPTION
... and adds barebones ActozLauncher / ShandaLauncher for future use (or not).

This refactor helps to prepare XL for the possibility of supporting logins and patching for KR/CN FFXIV, although there would be a lot more work/complexity there (especially around Dalamud and the different game versions). In reality, it's mainly to be able to track KR/CN game versions in Thaliak, though of course I'd love to try to clean things up and upstream these changes.
