### PR TITLE
Please stop running Crowdin schedule for forks, I don't want GitHub to land in my spam

### DIFF
--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   synchronize-with-crowdin:
+    if: github.repository_owner == 'goatcorp'
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
I've grown _very_ tired of the nightly mails that the crowdin action failed. Please help me reduce the risk of GitHub ending up in my spam.

![image](https://user-images.githubusercontent.com/6816490/167998354-d40d408b-ae8e-40d9-a961-72f10583b4d1.png)
