### PR TITLE
Fix UserPath with encrypted args

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -745,6 +745,8 @@ public class MainPage : Page
 
             runner = new UnixGameRunner(Program.CompatibilityTools, dalamudLauncher, dalamudOk);
 
+            // SE has its own way of encoding spaces when encrypting arguments, which interferes 
+            // with quoting, but they are necessary when passing paths unencrypted
             var userPath = Program.CompatibilityTools.UnixToWinePath(App.Settings.GameConfigPath.FullName);
             if (App.Settings.IsEncryptArgs.GetValueOrDefault(true))
                 gameArgs += $" UserPath={userPath}";

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -745,7 +745,12 @@ public class MainPage : Page
 
             runner = new UnixGameRunner(Program.CompatibilityTools, dalamudLauncher, dalamudOk);
 
-            gameArgs += $" UserPath=\"{Program.CompatibilityTools.UnixToWinePath(App.Settings.GameConfigPath.FullName)}\"";
+            var userPath = Program.CompatibilityTools.UnixToWinePath(App.Settings.GameConfigPath.FullName);
+            if (App.Settings.IsEncryptArgs.GetValueOrDefault(true))
+                gameArgs += $" UserPath={userPath}";
+            else
+                gameArgs += $" UserPath=\"{userPath}\"";
+
             gameArgs = gameArgs.Trim();
         }
         else


### PR DESCRIPTION
Only escape with double quotes when not encrypting args