### PR TITLE
Make process handle acquisition more robust

### DIFF
--- a/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
@@ -38,7 +38,10 @@ public class UnixDalamudRunner : IDalamudRunner
 
         environment.Add("DALAMUD_RUNTIME", dotnetRuntimePath);
 
-        var launchArguments = new List<string> { $"\"{runner.FullName}\"", "launch",
+        var launchArguments = new List<string> 
+        { 
+            $"\"{runner.FullName}\"", 
+            "launch",
             $"--mode={(loadMethod == DalamudLoadMethod.EntryPoint ? "entrypoint" : "inject")}",
             $"--game=\"{gameExePath}\"",
             $"--dalamud-working-directory=\"{startInfo.WorkingDirectory}\"",
@@ -77,7 +80,7 @@ public class UnixDalamudRunner : IDalamudRunner
             }
 
             var gameProcess = Process.GetProcessById(unixPid);
-            var handle = gameProcess.Handle;
+            Log.Verbose($"Got game process handle {gameProcess.Handle} with Unix pid {gameProcess.Id} and Wine pid {dalamudConsoleOutput.Pid}");
             return gameProcess;
         }
         catch (JsonReaderException ex)

--- a/src/XIVLauncher.Common.Windows/WindowsDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Windows/WindowsDalamudRunner.cs
@@ -64,7 +64,31 @@ public class WindowsDalamudRunner : IDalamudRunner
         try
         {
             var dalamudConsoleOutput = JsonConvert.DeserializeObject<DalamudConsoleOutput>(output);
-            var gameProcess = new ExistingProcess((IntPtr)dalamudConsoleOutput.Handle);
+            Process gameProcess;
+
+            if (dalamudConsoleOutput.Handle == 0) 
+            {
+                Log.Warning($"Dalamud returned NULL process handle, attempting to recover by creating a new one from pid {dalamudConsoleOutput.Pid}...");
+                gameProcess = Process.GetProcessById(dalamudConsoleOutput.Pid);
+            }
+            else 
+            {
+                gameProcess = new ExistingProcess((IntPtr)dalamudConsoleOutput.Handle);
+            }
+
+            try 
+            {
+                Log.Verbose($"Got game process handle {gameProcess.Handle} with pid {gameProcess.Id}");
+            }
+            catch (InvalidOperationException ex) 
+            {
+                Log.Error(ex, $"Dalamud returned invalid process handle {gameProcess.Handle}, attempting to recover by creating a new one from pid {dalamudConsoleOutput.Pid}...");
+                gameProcess = Process.GetProcessById(dalamudConsoleOutput.Pid);
+                Log.Warning($"Recovered with process handle {gameProcess.Handle}");
+            }
+
+            if (gameProcess.Id != dalamudConsoleOutput.Pid)
+                Log.Warning($"Internal Process ID {gameProcess.Id} does not match Dalamud provided one {dalamudConsoleOutput.Pid}");
 
             return gameProcess;
         }


### PR DESCRIPTION
Adds fallback logic to `WindowsDalamudRunner` in case the Dalamud provided process handle is invalid and better logging for that section.