### PR TITLE
Add a banner switch indicator

### DIFF
--- a/src/XIVLauncher/Windows/MainWindow.xaml
+++ b/src/XIVLauncher/Windows/MainWindow.xaml
@@ -69,6 +69,33 @@
                                 </Viewbox>
                             </materialDesign:Card>
 
+                            <Border CornerRadius="8" Background="#aa333333" VerticalAlignment="Bottom" HorizontalAlignment="Right" Margin="0,0,8,8">
+                                <ItemsControl x:Name="BannerDot" d:ItemsSource="{d:SampleData ItemCount=5}" Opacity="1"  >
+                                    <ItemsControl.LayoutTransform>
+                                        <TransformGroup>
+                                            <ScaleTransform/>
+                                            <SkewTransform/>
+                                            <RotateTransform Angle="-90"/>
+                                            <TranslateTransform/>
+                                        </TransformGroup>
+                                    </ItemsControl.LayoutTransform>
+                                    <ItemsControl.ItemTemplate>
+                                        <DataTemplate DataType="BannerDotInfo">
+                                            <RadioButton GroupName="banner" IsChecked="{Binding Active}" RenderTransformOrigin="0.5,0.5" MouseEnter="RadioButton_MouseEnter" MouseLeave="RadioButton_MouseLeave">
+                                                <RadioButton.RenderTransform>
+                                                    <TransformGroup>
+                                                        <ScaleTransform ScaleX="0.75" ScaleY="0.75"/>
+                                                        <SkewTransform/>
+                                                        <RotateTransform/>
+                                                        <TranslateTransform/>
+                                                    </TransformGroup>
+                                                </RadioButton.RenderTransform>
+                                            </RadioButton>
+                                        </DataTemplate>
+                                    </ItemsControl.ItemTemplate>
+                                </ItemsControl>
+                            </Border>
+
                             <materialDesign:Card
                                 Grid.Row="1"
                                 Grid.Column="0"


### PR DESCRIPTION
Quickly switch items by hovering.
There is no suitable control in Material Design, so I had to made one in a simple way. 

![snipaste_20220526_171859](https://user-images.githubusercontent.com/18360825/170458651-3619287d-3666-433d-bc69-5859487644f3.png)