### PR TITLE
Implementing repair for xlcore

### DIFF
--- a/src/XIVLauncher.Common/Patching/IndexedZiPatch/IIndexedZiPatchIndexInstaller.cs
+++ b/src/XIVLauncher.Common/Patching/IndexedZiPatch/IIndexedZiPatchIndexInstaller.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace XIVLauncher.Common.Patching.IndexedZiPatch
+{
+    public interface IIndexedZiPatchIndexInstaller : IDisposable
+    {
+        public event IndexedZiPatchInstaller.OnInstallProgressDelegate OnInstallProgress;
+        public event IndexedZiPatchInstaller.OnVerifyProgressDelegate OnVerifyProgress;
+
+        public Task ConstructFromPatchFile(IndexedZiPatchIndex patchIndex, int progressReportInterval = 250);
+
+        public Task VerifyFiles(bool refine = false, int concurrentCount = 8, CancellationToken? cancellationToken = null);
+
+        public Task MarkFileAsMissing(int targetIndex, CancellationToken? cancellationToken = null);
+
+        public Task SetTargetStreamFromPathReadOnly(int targetIndex, string path, CancellationToken? cancellationToken = null);
+
+        public Task SetTargetStreamFromPathReadWrite(int targetIndex, string path, CancellationToken? cancellationToken = null);
+
+        public Task SetTargetStreamsFromPathReadOnly(string rootPath, CancellationToken? cancellationToken = null);
+
+        public Task SetTargetStreamsFromPathReadWriteForMissingFiles(string rootPath, CancellationToken? cancellationToken = null);
+
+        public Task RepairNonPatchData(CancellationToken? cancellationToken = null);
+
+        public Task WriteVersionFiles(string rootPath, CancellationToken? cancellationToken = null);
+
+        public Task QueueInstall(int sourceIndex, Uri sourceUrl, string sid, int splitBy = 8, CancellationToken? cancellationToken = null);
+
+        public Task QueueInstall(int sourceIndex, FileInfo sourceFile, int splitBy = 8, CancellationToken? cancellationToken = null);
+
+        public Task Install(int concurrentCount, CancellationToken? cancellationToken = null);
+
+        public Task<List<SortedSet<Tuple<int, int>>>> GetMissingPartIndicesPerPatch(CancellationToken? cancellationToken = null);
+
+        public Task<List<SortedSet<int>>> GetMissingPartIndicesPerTargetFile(CancellationToken? cancellationToken = null);
+
+        public Task<SortedSet<int>> GetSizeMismatchTargetFileIndices(CancellationToken? cancellationToken = null);
+
+        public Task SetWorkerProcessPriority(ProcessPriorityClass subprocessPriority, CancellationToken? cancellationToken = null);
+    }
+}

--- a/src/XIVLauncher.Common/Patching/IndexedZiPatch/IndexedZiPatchIndexLocalInstaller.cs
+++ b/src/XIVLauncher.Common/Patching/IndexedZiPatch/IndexedZiPatchIndexLocalInstaller.cs
@@ -1,0 +1,130 @@
+﻿using Serilog;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace XIVLauncher.Common.Patching.IndexedZiPatch
+{
+    public class IndexedZiPatchIndexLocalInstaller : IIndexedZiPatchIndexInstaller
+    {
+        private int cancellationTokenCounter = 1;
+        private long lastProgressUpdateCounter = 0;
+        private bool isDisposed = false;
+        private IndexedZiPatchInstaller? instance;
+
+        public event IndexedZiPatchInstaller.OnInstallProgressDelegate OnInstallProgress;
+        public event IndexedZiPatchInstaller.OnVerifyProgressDelegate OnVerifyProgress;
+
+        public IndexedZiPatchIndexLocalInstaller()
+        {
+            this.instance = null;
+        }
+
+        public void Dispose()
+        {
+            if (this.isDisposed)
+                throw new ObjectDisposedException(GetType().FullName);
+
+            this.isDisposed = true;
+        }
+
+        public Task ConstructFromPatchFile(IndexedZiPatchIndex patchIndex, int progressReportInterval = 250)
+        {
+            this.instance?.Dispose();
+            this.instance = new(patchIndex)
+            {
+                ProgressReportInterval = progressReportInterval,
+            };
+            this.instance.OnInstallProgress += OnInstallProgress;
+            this.instance.OnVerifyProgress += OnVerifyProgress;
+            return Task.CompletedTask;
+        }
+
+        public async Task VerifyFiles(bool refine = false, int concurrentCount = 8, CancellationToken? cancellationToken = null)
+        {
+            await this.instance.VerifyFiles(refine, concurrentCount, cancellationToken);
+        }
+
+        public Task MarkFileAsMissing(int targetIndex, CancellationToken? cancellationToken = null)
+        {
+            this.instance.MarkFileAsMissing(targetIndex);
+            return Task.CompletedTask;
+        }
+
+        public Task SetTargetStreamFromPathReadOnly(int targetIndex, string path, CancellationToken? cancellationToken = null)
+        {
+            this.instance.SetTargetStreamForRead(targetIndex, new FileStream(path, FileMode.Open, FileAccess.Read));
+            return Task.CompletedTask;
+        }
+
+        public Task SetTargetStreamFromPathReadWrite(int targetIndex, string path, CancellationToken? cancellationToken = null)
+        {
+            this.instance.SetTargetStreamForWriteFromFile(targetIndex, new FileInfo(path));
+            return Task.CompletedTask;
+        }
+
+        public Task SetTargetStreamsFromPathReadOnly(string rootPath, CancellationToken? cancellationToken = null)
+        {
+            this.instance.SetTargetStreamsFromPathReadOnly(rootPath);
+            return Task.CompletedTask;
+        }
+
+        public Task SetTargetStreamsFromPathReadWriteForMissingFiles(string rootPath, CancellationToken? cancellationToken = null)
+        {
+            this.instance.SetTargetStreamsFromPathReadWriteForMissingFiles(rootPath);
+            return Task.CompletedTask;
+        }
+
+        public async Task RepairNonPatchData(CancellationToken? cancellationToken = null)
+        {
+            await this.instance.RepairNonPatchData(cancellationToken);
+        }
+
+        public Task WriteVersionFiles(string rootPath, CancellationToken? cancellationToken = null)
+        {
+            this.instance.WriteVersionFiles(rootPath);
+            return Task.CompletedTask;
+        }
+
+        public Task QueueInstall(int sourceIndex, Uri sourceUrl, string sid, int splitBy = 8, CancellationToken? cancellationToken = null)
+        {
+            this.instance.QueueInstall(sourceIndex, sourceUrl.OriginalString, sid, splitBy);
+            return Task.CompletedTask;
+        }
+
+        public Task QueueInstall(int sourceIndex, FileInfo sourceFile, int splitBy = 8, CancellationToken? cancellationToken = null)
+        {
+            this.instance.QueueInstall(sourceIndex, sourceFile, splitBy);
+            return Task.CompletedTask;
+        }
+
+        public async Task Install(int concurrentCount, CancellationToken? cancellationToken = null)
+        {
+            await this.instance.Install(concurrentCount, cancellationToken);
+        }
+
+        public Task<List<SortedSet<Tuple<int, int>>>> GetMissingPartIndicesPerPatch(CancellationToken? cancellationToken = null)
+        {
+            return Task.FromResult(this.instance.MissingPartIndicesPerPatch);
+        }
+
+        public Task<List<SortedSet<int>>> GetMissingPartIndicesPerTargetFile(CancellationToken? cancellationToken = null)
+        {
+            return Task.FromResult(this.instance.MissingPartIndicesPerTargetFile);
+        }
+
+        public Task<SortedSet<int>> GetSizeMismatchTargetFileIndices(CancellationToken? cancellationToken = null)
+        {
+            return Task.FromResult(this.instance.SizeMismatchTargetFileIndices);
+        }
+
+        public Task SetWorkerProcessPriority(ProcessPriorityClass subprocessPriority, CancellationToken? cancellationToken = null)
+        {
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/XIVLauncher.Common/Patching/IndexedZiPatch/IndexedZiPatchIndexRemoteInstaller.cs
+++ b/src/XIVLauncher.Common/Patching/IndexedZiPatch/IndexedZiPatchIndexRemoteInstaller.cs
@@ -11,7 +11,7 @@ using System.Threading.Tasks;
 
 namespace XIVLauncher.Common.Patching.IndexedZiPatch
 {
-    public class IndexedZiPatchIndexRemoteInstaller : IDisposable
+    public class IndexedZiPatchIndexRemoteInstaller : IIndexedZiPatchIndexInstaller
     {
         private readonly Process workerProcess;
         private readonly RpcBuffer subprocessBuffer;

--- a/src/XIVLauncher.Common/Patching/IndexedZiPatch/IndexedZiPatchPartLocator.cs
+++ b/src/XIVLauncher.Common/Patching/IndexedZiPatch/IndexedZiPatchPartLocator.cs
@@ -86,35 +86,26 @@ namespace XIVLauncher.Common.Patching.IndexedZiPatch
         public bool IsUnavailable => SourceIndex == SOURCE_INDEX_UNAVAILABLE;
         public bool IsFromSourceFile => !IsAllZeros && !IsEmptyBlock && !IsUnavailable;
 
-        public unsafe void WriteTo(BinaryWriter writer)
+        public void WriteTo(BinaryWriter writer)
         {
-            int unitSize = Marshal.SizeOf(this);
-            using var buf = ReusableByteBufferManager.GetBuffer(unitSize);
-
-            fixed (byte* pBuf = buf.Buffer)
-            {
-                fixed (IndexedZiPatchPartLocator* pLocator = &this)
-                {
-                    Buffer.MemoryCopy(pLocator, pBuf, unitSize, unitSize);
-                }
-            }
-
-            writer.Write(buf.Buffer, 0, unitSize);
+            writer.Write(this.TargetOffsetUint);
+            writer.Write(this.SourceOffsetUint);
+            writer.Write(this.TargetSizeAndFlags);
+            writer.Write(this.Crc32OrPlaceholderEntryDataUnits);
+            writer.Write(this.SplitDecodedSourceFromUshort);
+            writer.Write(this.TargetIndexByte);
+            writer.Write(this.SourceIndexByte);
         }
 
-        public unsafe void ReadFrom(BinaryReader reader)
+        public void ReadFrom(BinaryReader reader)
         {
-            int unitSize = Marshal.SizeOf(this);
-            using var buf = ReusableByteBufferManager.GetBuffer(unitSize);
-            reader.Read(buf.Buffer, 0, unitSize);
-
-            fixed (byte* pBuf = buf.Buffer)
-            {
-                fixed (IndexedZiPatchPartLocator* pLocator = &this)
-                {
-                    Buffer.MemoryCopy(pBuf, pLocator, unitSize, unitSize);
-                }
-            }
+            this.TargetOffsetUint = reader.ReadUInt32();
+            this.SourceOffsetUint = reader.ReadUInt32();
+            this.TargetSizeAndFlags = reader.ReadUInt32();
+            this.Crc32OrPlaceholderEntryDataUnits = reader.ReadUInt32();
+            this.SplitDecodedSourceFromUshort = reader.ReadUInt16();
+            this.TargetIndexByte = reader.ReadByte();
+            this.SourceIndexByte = reader.ReadByte();
         }
 
         public int CompareTo(IndexedZiPatchPartLocator other)
@@ -278,11 +269,12 @@ namespace XIVLauncher.Common.Patching.IndexedZiPatch
             if (bufferSize == 0)
                 return 0;
 
+
             if (IsDeflatedBlockData)
             {
                 using var inflatedBuffer = ReusableByteBufferManager.GetBuffer(MaxSourceSize);
                 using (var stream = new DeflateStream(new MemoryStream(sourceSegment, sourceSegmentOffset, sourceSegmentLength - sourceSegmentOffset), CompressionMode.Decompress, true))
-                    stream.Read(inflatedBuffer.Buffer, 0, inflatedBuffer.Buffer.Length);
+                    stream.FullRead(inflatedBuffer.Buffer, 0, inflatedBuffer.Buffer.Length);
                 if (verify && VerifyDataResult.Pass != Verify(inflatedBuffer.Buffer, (int)SplitDecodedSourceFrom, (int)TargetSize))
                     throw new IOException("Verify failed on reconstruct (inflate)");
 

--- a/src/XIVLauncher.Common/Patching/Util/FullDeflateStreamReader.cs
+++ b/src/XIVLauncher.Common/Patching/Util/FullDeflateStreamReader.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+// ReSharper disable InconsistentNaming
+
+namespace XIVLauncher.Common.Patching.Util
+{
+    // works around https://docs.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/6.0/partial-byte-reads-in-streams
+    static class FullDeflateStreamReader
+    {
+        public static void FullRead(this DeflateStream stream, byte[] array, int offset, int count)
+        {
+            int totalRead = 0;
+            while (totalRead < count)
+            {
+                int bytesRead = stream.Read(array, offset + totalRead, count - totalRead);
+                if (bytesRead == 0) break;
+                totalRead += bytesRead;
+            }
+        }
+    }
+}

--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -17,6 +17,8 @@ using XIVLauncher.Common.Unix.Compatibility;
 using XIVLauncher.Common.Unix.Compatibility.GameFixes;
 using XIVLauncher.Common.Util;
 using XIVLauncher.Core.Accounts;
+using XIVLauncher.Core.Configuration;
+using XIVLauncher.Common.Game.Exceptions;
 
 namespace XIVLauncher.Core.Components.MainPage;
 
@@ -1086,124 +1088,76 @@ public class MainPage : Page
     private async Task<bool> RepairGame(Launcher.LoginResult loginResult)
     {
         var doLogin = false;
-        var mutex = new Mutex(false, "XivLauncherIsPatching");
-        /*
 
-        if (mutex.WaitOne(0, false))
+        // BUG(goat): This check only behaves correctly on Windows - the mutex doesn't seem to disappear on Linux, .NET issue?
+#if WIN32
+        using var mutex = new Mutex(false, "XivLauncherIsPatching");
+
+        if (!mutex.WaitOne(0, false))
         {
-            Debug.Assert(loginResult.PendingPatches != null, "loginResult.PendingPatches != null ASSERTION FAILED");
-            Debug.Assert(loginResult.PendingPatches.Length != 0, "loginResult.PendingPatches.Length != 0 ASSERTION FAILED");
+            App.ShowMessageBlocking(Loc.Localize("PatcherAlreadyInProgress", "XIVLauncher is already patching your game in another instance. Please check if XIVLauncher is still open."),
+                "XIVLauncher");
+            Environment.Exit(0);
+            return false; // This line will not be run.
+        }
+#endif
 
-            Log.Information("STARTING REPAIR");
+        Debug.Assert(loginResult.PendingPatches != null, "loginResult.PendingPatches != null ASSERTION FAILED");
+        Debug.Assert(loginResult.PendingPatches.Length != 0, "loginResult.PendingPatches.Length != 0 ASSERTION FAILED");
 
-            using var verify = new PatchVerifier(CommonSettings.Instance, loginResult, 20, loginResult.OauthLogin.MaxExpansion);
+        Log.Information("STARTING REPAIR");
 
-            Hide();
-            IsEnabled = false;
+        // TODO: bundle the PatchInstaller with xl-core on Windows and run this remotely
+        using var verify = new PatchVerifier(Program.CommonSettings, loginResult, 20, loginResult.OauthLogin.MaxExpansion, false);
 
-            var progressDialog = _window.Dispatcher.Invoke(() =>
+        for (bool doVerify = true; doVerify;)
+        {
+            // TODO: show progress here
+            this.App.StartLoading($"Now repairing...", canCancel: false, isIndeterminate: true);
+
+            verify.Start();
+            await verify.WaitForCompletion().ConfigureAwait(false);
+
+            App.State = LauncherApp.LauncherState.Main;
+
+            switch (verify.State)
             {
-                var d = new GameRepairProgressWindow(verify);
-                if (_window.IsVisible)
-                    d.Owner = _window;
-                d.Show();
-                d.Activate();
-                return d;
-            });
-
-            for (bool doVerify = true; doVerify;)
-            {
-                progressDialog.Dispatcher.Invoke(progressDialog.Show);
-
-                verify.Start();
-                await verify.WaitForCompletion().ConfigureAwait(false);
-
-                progressDialog.Dispatcher.Invoke(progressDialog.Hide);
-
-                switch (verify.State)
-                {
-                    case PatchVerifier.VerifyState.Done:
-                        switch (CustomMessageBox.Builder
-                                                .NewFrom(verify.NumBrokenFiles switch
-                                                {
-                                                    0 => Loc.Localize("GameRepairSuccess0", "All game files seem to be valid."),
-                                                    1 => Loc.Localize("GameRepairSuccess1", "XIVLauncher has successfully repaired 1 game file."),
-                                                    _ => string.Format(Loc.Localize("GameRepairSuccessPlural", "XIVLauncher has successfully repaired {0} game files."), verify.NumBrokenFiles),
-                                                })
-                                                .WithImage(MessageBoxImage.Information)
-                                                .WithButtons(MessageBoxButton.YesNoCancel)
-                                                .WithYesButtonText(Loc.Localize("GameRepairSuccess_LaunchGame", "_Launch game"))
-                                                .WithNoButtonText(Loc.Localize("GameRepairSuccess_VerifyAgain", "_Verify again"))
-                                                .WithCancelButtonText(Loc.Localize("GameRepairSuccess_Close", "_Close"))
-                                                .WithParentWindow(_window)
-                                                .Show())
+                case PatchVerifier.VerifyState.Done:
+                    // TODO: ask the user if they want to login or rerun after repair
+                    App.ShowMessageBlocking(verify.NumBrokenFiles switch
                         {
-                            case MessageBoxResult.Yes:
-                                doLogin = true;
-                                doVerify = false;
-                                break;
+                            0 => Loc.Localize("GameRepairSuccess0", "All game files seem to be valid."),
+                            1 => Loc.Localize("GameRepairSuccess1", "XIVLauncher has successfully repaired 1 game file."),
+                            _ => string.Format(Loc.Localize("GameRepairSuccessPlural", "XIVLauncher has successfully repaired {0} game files."), verify.NumBrokenFiles),
+                        });
 
-                            case MessageBoxResult.No:
-                                doLogin = false;
-                                doVerify = true;
-                                break;
+                    doVerify = false;
+                    break;
 
-                            case MessageBoxResult.Cancel:
-                                doLogin = doVerify = false;
-                                break;
-                        }
+                case PatchVerifier.VerifyState.Error:
+                    doLogin = false;
 
-                        break;
+                    if (verify.LastException is NoVersionReferenceException)
+                    {
+                        App.ShowMessageBlocking(Loc.Localize("NoVersionReferenceError",
+                                                        "The version of the game you are on cannot be repaired by XIVLauncher yet, as reference information is not yet available.\nPlease try again later."));
+                    }
+                    else
+                    {
+                        App.ShowMessageBlocking(verify.LastException + "\n\n" + Loc.Localize("GameRepairError", "An error occurred while repairing the game files.\nYou may have to reinstall the game."));
+                    }
 
-                    case PatchVerifier.VerifyState.Error:
-                        doLogin = false;
+                    doVerify = false;
+                    break;
 
-                        if (verify.LastException is NoVersionReferenceException)
-                        {
-                            doVerify = CustomMessageBox.Builder
-                                                       .NewFrom(Loc.Localize("NoVersionReferenceError",
-                                                           "The version of the game you are on cannot be repaired by XIVLauncher yet, as reference information is not yet available.\nPlease try again later."))
-                                                       .WithImage(MessageBoxImage.Exclamation)
-                                                       .WithButtons(MessageBoxButton.OKCancel)
-                                                       .WithOkButtonText(Loc.Localize("GameRepairSuccess_TryAgain", "_Try again"))
-                                                       .WithParentWindow(_window)
-                                                       .Show() == MessageBoxResult.OK;
-                        }
-                        else
-                        {
-                            doVerify = CustomMessageBox.Builder
-                                                       .NewFrom(verify.LastException, "PatchVerifier")
-                                                       .WithAppendText("\n\n")
-                                                       .WithAppendText(Loc.Localize("GameRepairError", "An error occurred while repairing the game files.\nYou may have to reinstall the game."))
-                                                       .WithImage(MessageBoxImage.Exclamation)
-                                                       .WithButtons(MessageBoxButton.OKCancel)
-                                                       .WithOkButtonText(Loc.Localize("GameRepairSuccess_TryAgain", "_Try again"))
-                                                       .WithParentWindow(_window)
-                                                       .Show() == MessageBoxResult.OK;
-                        }
-
-                        break;
-
-                    case PatchVerifier.VerifyState.Cancelled:
-                        doLogin = doVerify = false;
-                        break;
-                }
+                case PatchVerifier.VerifyState.Cancelled:
+                    doLogin = doVerify = false;
+                    break;
             }
+        }
 
-            progressDialog.Dispatcher.Invoke(progressDialog.Close);
-            mutex.Close();
-            mutex = null;
-        }
-        else
-        {
-            CustomMessageBox.Show(Loc.Localize("PatcherAlreadyInProgress", "XIVLauncher is already patching your game in another instance. Please check if XIVLauncher is still open."), "XIVLauncher",
-                MessageBoxButton.OK, MessageBoxImage.Error, parentWindow: _window);
-        }
 
         return doLogin;
-        */
-
-        throw new NotImplementedException();
     }
 
     private void Hide()

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -108,6 +108,7 @@ public class SettingsTabWine : SettingsTab
     public override void Save()
     {
         base.Save();
-        Program.CreateCompatToolsInstance();
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            Program.CreateCompatToolsInstance();
     }
 }


### PR DESCRIPTION
This adds a new class `IndexedZiPatchIndexLocalInstaller` and fixes an issue where the patch index files were not being read correctly on non-windows platforms.