### PR TITLE
Update DalamudUpdater.cs

### DIFF
--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
@@ -161,8 +161,10 @@ namespace XIVLauncher.Common.Dalamud
         {
             var settings = DalamudSettings.GetSettings(this.configDirectory);
 
-            // GitHub requires TLS 1.2, we need to hardcode this for Windows 7
+        if (System.Environment.OSVersion.ToString() == "6.1")
+        {
             ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
+        }
 
             var (versionInfoRelease, versionInfoStaging) = await GetVersionInfo(settings).ConfigureAwait(false);
 


### PR DESCRIPTION
Applies GitHub TLS1.2 fixes for Windows 7 only whenever Windows 7 is detected, leaving other OSes to decide best modern version to use.