### PR TITLE
xlcore DC travel update killswitch

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -173,6 +173,20 @@ public class MainPage : Page
         if (!bootRes)
             return false;
 
+        /* ============== 6.18 DC TRAVEL UPDATE ============== */
+        var bootver = SeVersion.Parse(Repository.Boot.GetVer(App.Settings.GamePath));
+        var ver615 = SeVersion.Parse("2022.03.25.0000.0001");
+
+        if (bootver > ver615)
+        {
+            throw new Exception(Loc.Localize("KillswitchText", "XIVLauncher cannot start the game at this time, as Square Enix has made changes to the login process." +
+                                                                 "\nWe need to adjust to these changes and verify that our adjustments are safe before we can re-enable the launcher. Please try again later." +
+                                                                 "\n\nWe apologize for these circumstances.\n\nYou can use the \"Official Launcher\" button below to start the official launcher." +
+                                                                 "\n"));
+        }
+        /* =================================================== */
+
+
         var otp = string.Empty;
 
         if (isOtp)


### PR DESCRIPTION
Rudimentary implementation of the DC travel killswitch for xlcore.

Doesn't open the SE launcher yet, but better than nothing I guess...