### PR TITLE
Add mostly-working integrity check to xlcore

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics;
@@ -57,7 +57,14 @@ public class CompatibilityTools
         this.toolDirectory = new DirectoryInfo(Path.Combine(toolsFolder.FullName, "beta"));
         this.dxvkDirectory = new DirectoryInfo(Path.Combine(toolsFolder.FullName, "dxvk"));
 
-        this.logWriter = new StreamWriter(wineSettings.LogFile.FullName);
+        try
+        {
+            this.logWriter = new StreamWriter(wineSettings.LogFile.FullName);
+        }
+        catch (IOException e)
+        {
+            // For some reason, this is called on Windows, and then it crashes xlcore because wine.log is considered open by another process already.
+        }
 
         if (wineSettings.StartupType == WineStartupType.Managed)
         {

--- a/src/XIVLauncher.Common/Game/IntegrityCheck.cs
+++ b/src/XIVLauncher.Common/Game/IntegrityCheck.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Serilog;
+using XIVLauncher.Common.Util;
 
 namespace XIVLauncher.Common.Game
 {
@@ -110,7 +111,7 @@ namespace XIVLauncher.Common.Game
                 var relativePath = file.FullName.Substring(rootDirectory.Length);
 
                 // for unix compatibility with windows-generated integrity
-                if (!OperatingSystem.IsWindows())
+                if (PlatformHelpers.GetPlatform() == Platform.Win32 || PlatformHelpers.GetPlatform() ==  Platform.Win32OnLinux)
                 {
 #if DEBUG
                     Log.Debug($"{relativePath} swapping to {relativePath.Replace("/", "\\")}");

--- a/src/XIVLauncher.Common/Game/IntegrityCheck.cs
+++ b/src/XIVLauncher.Common/Game/IntegrityCheck.cs
@@ -139,7 +139,10 @@ namespace XIVLauncher.Common.Game
             }
 
             foreach (var dir in directory.GetDirectories())
-                CheckDirectory(dir, sha1, rootDirectory, ref results, progress, onlyIndex);
+            {
+                if (!dir.FullName.ToLower().Contains("shade"))
+                    CheckDirectory(dir, sha1, rootDirectory, ref results, progress, onlyIndex);
+            }
         }
     }
 }

--- a/src/XIVLauncher.Common/Game/IntegrityCheck.cs
+++ b/src/XIVLauncher.Common/Game/IntegrityCheck.cs
@@ -60,9 +60,9 @@ namespace XIVLauncher.Common.Game
                 if (onlyIndex && (!hashEntry.Key.EndsWith(".index") && !hashEntry.Key.EndsWith(".index2")))
                     continue;
 
-                if (localIntegrity.Hashes.Any(h => h.Key.Replace("/", "\\") == hashEntry.Key))
+                if (localIntegrity.Hashes.Any(h => h.Key == hashEntry.Key))
                 {
-                    if (localIntegrity.Hashes.First(h => h.Key.Replace("/", "\\") == hashEntry.Key).Value != hashEntry.Value)
+                    if (localIntegrity.Hashes.First(h => h.Key == hashEntry.Key).Value != hashEntry.Value)
                     {
                         report += $"Mismatch: {hashEntry.Key}\n";
                         failed = true;
@@ -89,6 +89,9 @@ namespace XIVLauncher.Common.Game
         public static async Task<IntegrityCheckResult> RunIntegrityCheckAsync(DirectoryInfo gamePath,
             IProgress<IntegrityCheckProgress> progress, bool onlyIndex = false)
         {
+#if DEBUG
+            Log.Debug($"Platform identified as {PlatformHelpers.GetPlatform()}");
+#endif
             var hashes = new Dictionary<string, string>();
 
             using (var sha1 = new SHA1Managed())
@@ -110,14 +113,12 @@ namespace XIVLauncher.Common.Game
             {
                 var relativePath = file.FullName.Substring(rootDirectory.Length);
 
-                // for unix compatibility with windows-generated integrity
-                if (PlatformHelpers.GetPlatform() == Platform.Win32 || PlatformHelpers.GetPlatform() ==  Platform.Win32OnLinux)
-                {
+
 #if DEBUG
-                    Log.Debug($"{relativePath} swapping to {relativePath.Replace("/", "\\")}");
+                Log.Debug($"{relativePath} swapping to {relativePath.Replace("/", "\\")}");
 #endif
-                    relativePath = relativePath.Replace("/", "\\");
-                }
+                // for unix compatibility with windows-generated integrity files.
+                relativePath = relativePath.Replace("/", "\\");
                 
 
                 if (!relativePath.StartsWith("\\"))

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -44,7 +44,7 @@ class Program
     private static bool showImGuiDemoWindow = true;
 
     private static LauncherApp launcherApp;
-    private static Storage storage;
+    public static Storage storage { get; private set; }
     public static DirectoryInfo DotnetRuntime => storage.GetFolder("runtime");
 
     // TODO: We don't have the steamworks api for this yet.


### PR DESCRIPTION
This add an Integrity Check button to XLCore's settings, right below the gamepath text field.

Under the hood, it runs the normal integrity process, but then swaps the path delimiters to backslashes, so they'll line up with a Windows-made integrity report.

I'm not able to make a modal display during the check, or note which file is being checked in a modal and need some help there. If there's a better way to do it, lemme know or please help me fix my code!

After the check has ran, a modal will be displayed with some info on the results, directly copied from the XAML code, so Loc can probably be matched up later to reduce work.