### PR TITLE
Bump version of Mac App Zip

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/GameFixes/Implementations/MacVideoFix.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/GameFixes/Implementations/MacVideoFix.cs
@@ -7,7 +7,7 @@ namespace XIVLauncher.Common.Unix.Compatibility.GameFixes.Implementations;
 
 public class MacVideoFix : GameFix
 {
-    private const string MAC_ZIP_URL = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-1.0.7.zip";
+    private const string MAC_ZIP_URL = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-1.0.8.zip";
 
     public MacVideoFix(DirectoryInfo gameDirectory, DirectoryInfo configDirectory, DirectoryInfo winePrefixDirectory, DirectoryInfo tempDirectory)
         : base(gameDirectory, configDirectory, winePrefixDirectory, tempDirectory)


### PR DESCRIPTION
Seems SE has taken off the old 1.0.7 link from their origin server and it is starting to 404 for some regions (1.0.8 download speeds will probably be slow in the beginning but should stabilize after a while)