### PR TITLE
Ignore GShade folders on integrity check and repair

### DIFF
--- a/src/XIVLauncher.Common/Game/Patch/PatchVerifier.cs
+++ b/src/XIVLauncher.Common/Game/Patch/PatchVerifier.cs
@@ -40,6 +40,9 @@ namespace XIVLauncher.Common.Game.Patch
 
             // Repair recycle bin folder.
             new Regex(@"^repair_recycler/.*$", RegexOptions.IgnoreCase),
+
+            // Ignore gshade folders. Unless someone wants to handle the symlinked folder, just skip recycling them.
+            new Regex(@"^gshade-(shader|preset)s$", RegexOptions.IgnoreCase),
         };
 
         private readonly ISettings _settings;


### PR DESCRIPTION
Very basic methods to skip integrity checking/repairing GShade folders.

Speeds up integrity and makes repair stop breaking gshade for every game on the computer.