### PR TITLE
fix: crash when using dalamudRunner argument

### DIFF
--- a/src/XIVLauncher/App.xaml.cs
+++ b/src/XIVLauncher/App.xaml.cs
@@ -41,6 +41,7 @@ namespace XIVLauncher
 #endif
 
         private MainWindow _mainWindow;
+        private FileInfo _dalamudRunnerOverride = null;
 
         public static bool GlobalIsDisableAutologin { get; private set; }
         public static byte[] GlobalSteamTicket { get; private set; }
@@ -74,7 +75,7 @@ namespace XIVLauncher
                 }
                 else if (arg.StartsWith("--dalamudRunner=", StringComparison.Ordinal))
                 {
-                    DalamudUpdater.RunnerOverride = new FileInfo(arg.Substring(16));
+                    this._dalamudRunnerOverride = new FileInfo(arg.Substring(16));
                 }
             }
 
@@ -238,6 +239,11 @@ namespace XIVLauncher
                         new DirectoryInfo(Paths.RoamingPath),
                         UniqueIdCache,
                         Settings.DalamudRolloutBucket);
+
+                    if (this._dalamudRunnerOverride != null)
+                    {
+                        DalamudUpdater.RunnerOverride = this._dalamudRunnerOverride;
+                    }
 
                     Settings.DalamudRolloutBucket = DalamudUpdater.RolloutBucket;
 


### PR DESCRIPTION
Fixes #1088 .
Didn't want to separate the argument parsing, so just using a temporary field.