### PR TITLE
Removes the Flatpak limit for gamemode, small lib edit

### DIFF
--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -24,19 +24,17 @@ public class SettingsTabWine : SettingsTab
                 CheckVisibility = () => startupTypeSetting.Value == WineStartupType.Custom
             },
 
-#if !FLATPAK
             new SettingsEntry<bool>("Enable Feral's GameMode", "Enable launching with Feral Interactive's GameMode CPU optimizations.", () => Program.Config.GameModeEnabled ?? true, b => Program.Config.GameModeEnabled = b)
             {
                 CheckVisibility = () => RuntimeInformation.IsOSPlatform(OSPlatform.Linux),
                 CheckValidity = b =>
                 {
-                    if (b == true && !File.Exists("/usr/lib/libgamemodeauto.so.0"))
+                    if (b == true && (!File.Exists("/usr/lib/libgamemodeauto.so.0") && !File.Exists("/app/lib/libgamemodeauto.so.0")))
                         return "GameMode not detected.";
 
                     return null;
                 }
             },
-#endif
 
             new SettingsEntry<bool>("Enable DXVK ASYNC", "Enable DXVK ASYNC patch.", () => Program.Config.DxvkAsyncEnabled ?? true, b => Program.Config.DxvkAsyncEnabled = b),
             new SettingsEntry<bool>("Enable ESync", "Enable eventfd-based synchronization.", () => Program.Config.ESyncEnabled ?? true, b => Program.Config.ESyncEnabled = b),


### PR DESCRIPTION
It now checks /app/lib/ and /usr/lib/, since the Flatpak needs to have user-added deps in /app/.

I cancelled the previous PR, as there were unnecessary commits, and this would clean up the history a bit.