### PR TITLE
Address Steam Overlay Issues on Linux platforms [Needs Help Cleaning Up!]

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -196,7 +196,7 @@ public class CompatibilityTools
         {
             // If this is the actual RunInPrefix that is running FFXIV (not wine setup commands) then we should
             // activate the steam overlay lib
-            ldPreload = ldPreload.Equals("") ? "~/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so" : ldPreload + ":~/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so";
+            ldPreload = ldPreload.Equals("") ? "/home/mbutler/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so" : ldPreload + ":/home/mbutler/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so";
         }
 
         wineEnviromentVariables.Add("DXVK_HUD", dxvkHud);

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -123,7 +123,7 @@ public class CompatibilityTools
         var psi = new ProcessStartInfo(Wine64Path);
         psi.Arguments = command;
 
-        if (command.Contains("ffxiv_dx11.exe"))
+        if (command.Contains("ffxiv_dx11.exe") || command.Contains("ffxiv.exe"))
         {
             this.isLaunchingFfxivExe = true;
         }
@@ -196,7 +196,7 @@ public class CompatibilityTools
         {
             // If this is the actual RunInPrefix that is running FFXIV (not wine setup commands) then we should
             // activate the steam overlay lib
-            ldPreload = ldPreload.Equals("") ? "/home/mbutler/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so" : ldPreload + ":/home/mbutler/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so";
+            ldPreload = ldPreload.Equals("") ? "~/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so" : ldPreload + ":~/.local/share/Steam/ubuntu12_64/gameoverlayrenderer.so";
         }
 
         wineEnviromentVariables.Add("DXVK_HUD", dxvkHud);

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -157,13 +157,15 @@ public class CompatibilityTools
         psi.WorkingDirectory = workingDirectory;
 
         string overlayFix = Environment.GetEnvironmentVariable("OVERLAY_FIX") ?? "";
-        string argList = psi.ArgumentList.Aggregate(string.Empty, (a, b) => a + " " + b);
+        string argList = psi.ArgumentList.Aggregate(string.Empty, (a, b) => a + " " + b) + " " + psi.Arguments;
         bool isLaunchingFfxivExe = false;
 
         if (argList.Contains("ffxiv_dx11.exe") || argList.Contains("ffxiv.exe"))
         {
             isLaunchingFfxivExe = true;
         }
+
+        Log.Verbose("DEBUG: {overlayFix} {argList} {isLaunchingFfxivExe}", overlayFix, argList, isLaunchingFfxivExe);
 
         var wineEnviromentVariables = new Dictionary<string, string>();
         wineEnviromentVariables.Add("WINEPREFIX", Settings.Prefix.FullName);
@@ -190,7 +192,7 @@ public class CompatibilityTools
             ldPreload = ldPreload.Equals("") ? "libgamemodeauto.so.0" : ldPreload + ":libgamemodeauto.so.0";
         }
 
-        if (isLaunchingFfxivExe && !string.IsNullOrEmpty(overlayFix))
+        if (isLaunchingFfxivExe && overlayFix.Contains("true"))
         {
             // If this is the actual RunInPrefix that is running FFXIV (not wine setup commands) then we should
             // activate the steam overlay lib but otherwise we should NOT activate the SteamOverlay

--- a/src/XIVLauncher.Core/XIVLauncher.Core.csproj
+++ b/src/XIVLauncher.Core/XIVLauncher.Core.csproj
@@ -14,7 +14,6 @@
     <AssemblyVersion>$(Version)</AssemblyVersion>
 
     <RuntimeIdentifiers>win10-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <PublishSingleFile>true</PublishSingleFile>
     <!-- <SelfContained>true</SelfContained> -->
 

--- a/src/XIVLauncher.Core/XIVLauncher.Core.csproj
+++ b/src/XIVLauncher.Core/XIVLauncher.Core.csproj
@@ -14,6 +14,7 @@
     <AssemblyVersion>$(Version)</AssemblyVersion>
 
     <RuntimeIdentifiers>win10-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+    <RuntimeIdentifier>linux-x64</RuntimeIdentifier>
     <PublishSingleFile>true</PublishSingleFile>
     <!-- <SelfContained>true</SelfContained> -->
 


### PR DESCRIPTION
Let me prefix this by saying I don't really know what I'm doing!!

System: Manjaro Linux
Graphics: Radeon 6700 XT
Version of FFXIV: Steam version (bought it on Steam)
Input Device: Steam Controller with wireless USB dongle

I set out to try fixing the Steam Overlay issue(s) I've been having with XIVLauncher. Namely, I couldn't use Shift + Tab or Press the Steam button on my Steam Controller while in game; nothing would happen. Furthermore, the custom touch menus I set up weren't showing, making the input customization less useful.

I should note that I was using the Flatpak version of XIVLauncher at first, where the Steam Overlay didn't work at all. I then installed `xivlauncher-git` from the AUR, set it all up properly, and the Steam Overlay actually worked slightly better but there were still some major issues; on some screens in FFXIV it wouldn't show at all, and if it did show, sometimes it was super laggy and unusable.

After much searching I found this related issue: https://github.com/ValveSoftware/steam-for-linux/issues/7172 which is an issue for the game Wakfu which also uses a launcher. That issue's workaround is to first set LD_PRELOAD to empty (`LD_PRELOAD=`) and then in the launcher, add back `LD_PRELOAD=/path/to/gameoverlayrenderer.so /path/to/game.exe` right before it finally launches the game.

Unfortunately, I can't find a way of adding such a workaround to XIVLauncher without modifying the cs code, so here we are.

The important thing is that we DON'T want to show the Steam Overlay in any exe except the last and final FFXIV exe launch, so that Steam doesn't get confused or think the game is closed.  That's why my hack checks in `RunInPrefix` if we are launching FFXIV or just a setup wine command. 

Right now this PR is not mergeable of course, as it even has my own filesystem's path in the code since I'm not sure about how to make this portable -- I tried using `~` but it didn't work. Maybe we can just support a custom ENV variable like `FFXIV_ENV_VARS=name1:value1,name2:value2` and then we can just insert these as `name1=value1 name2=value2 /path/to/wine64...` right before launching FFXIV.

I haven't tested this change with Flatpak, since I don't know how to build a Flatpak yet, so I'm not sure if it would even fix the issue there. But I'm happy at least I have the workaround on my own machine.

Many thanks to Franz & Julian in Discord with help on how to compile the code.

## Testing

I added the Build to Steam and set this as the launch options:

```
LD_PRELOAD= OVERLAY_FIX=true XL_SECRET_PROVIDER=FILE %command%
```

This makes the Steam overlay not appear in XIVLauncher itself, but once the game is launched, the SO works great. One odd thing is that the sound effect is really weird when operating the SO menu, but that is a minor issue.