### PR TITLE
[Add-Feature] Add custom dxvk_overlay option

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -173,7 +173,7 @@ public class CompatibilityTools
             Dxvk.DxvkHudType.None => "0",
             Dxvk.DxvkHudType.Fps => "fps",
             Dxvk.DxvkHudType.Full => "full",
-			Dxvk.DxvkHudType.Custom => Settings.DxvkHudCustomString,
+            Dxvk.DxvkHudType.Custom => Settings.DxvkHudCustomString,
             _ => throw new ArgumentOutOfRangeException()
         };
 

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -173,6 +173,7 @@ public class CompatibilityTools
             Dxvk.DxvkHudType.None => "0",
             Dxvk.DxvkHudType.Fps => "fps",
             Dxvk.DxvkHudType.Full => "full",
+			Dxvk.DxvkHudType.Custom => Settings.DxvkHudCustomString,
             _ => throw new ArgumentOutOfRangeException()
         };
 

--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
@@ -51,5 +51,8 @@ public static class Dxvk
 
         [SettingsDescription("Full", "Show everything")]
         Full,
+
+        [SettingsDescription("Custom", "Custom dxvk hud string")]
+        Custom,
     }
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -25,7 +25,7 @@ public class WineSettings
 
     public DirectoryInfo Prefix { get; private set; }
 
-    public WineSettings(WineStartupType? startupType, string customBinPath, string debugVars, string dxvkHudCustomString, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
+    public WineSettings(WineStartupType? startupType, string customBinPath, string dxvkHudCustomString, string debugVars,  FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
     {
         this.StartupType = startupType ?? WineStartupType.Custom;
         this.CustomBinPath = customBinPath;

--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -15,6 +15,7 @@ public class WineSettings
 {
     public WineStartupType StartupType { get; private set; }
     public string CustomBinPath { get; private set; }
+	public string DxvkHudCustomString { get; private set; }
 
     public string EsyncOn { get; private set; }
     public string FsyncOn { get; private set; }
@@ -24,10 +25,11 @@ public class WineSettings
 
     public DirectoryInfo Prefix { get; private set; }
 
-    public WineSettings(WineStartupType? startupType, string customBinPath, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
+    public WineSettings(WineStartupType? startupType, string customBinPath, string debugVars, string dxvkHudCustomString, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
     {
         this.StartupType = startupType ?? WineStartupType.Custom;
         this.CustomBinPath = customBinPath;
+		this.DxvkHudCustomString = dxvkHudCustomString;
         this.EsyncOn = (esyncOn ?? false) ? "1" : "0";
         this.FsyncOn = (fsyncOn ?? false) ? "1" : "0";
         this.DebugVars = debugVars;

--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -15,7 +15,7 @@ public class WineSettings
 {
     public WineStartupType StartupType { get; private set; }
     public string CustomBinPath { get; private set; }
-	public string DxvkHudCustomString { get; private set; }
+    public string DxvkHudCustomString { get; private set; }
 
     public string EsyncOn { get; private set; }
     public string FsyncOn { get; private set; }
@@ -29,7 +29,7 @@ public class WineSettings
     {
         this.StartupType = startupType ?? WineStartupType.Custom;
         this.CustomBinPath = customBinPath;
-		this.DxvkHudCustomString = dxvkHudCustomString;
+        this.DxvkHudCustomString = dxvkHudCustomString;
         this.EsyncOn = (esyncOn ?? false) ? "1" : "0";
         this.FsyncOn = (fsyncOn ?? false) ? "1" : "0";
         this.DebugVars = debugVars;

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -9,6 +9,7 @@ namespace XIVLauncher.Core.Components.SettingsPage.Tabs;
 public class SettingsTabWine : SettingsTab
 {
     private SettingsEntry<WineStartupType> startupTypeSetting;
+	private SettingsEntry<Dxvk.DxvkHudType> dxvkOverlaySetting;
 
     public SettingsTabWine()
     {

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -58,7 +58,7 @@ public class SettingsTabWine : SettingsTab
                 "Custom DXVK Overlay string. For example fps,frametimes,gpuload,version",
                 () => Program.Config.DxvkHudCustomString, s => Program.Config.DxvkHudCustomString = s)
             {
-                CheckVisibility = () => dxvkOverlaySetting.Value == DxvkHudType.Custom
+                CheckVisibility = () => dxvkOverlaySetting.Value == Dxvk.DxvkHudType.Custom
             },
             new SettingsEntry<string>("WINEDEBUG Variables", "Configure debug logging for wine. Useful for troubleshooting.", () => Program.Config.WineDebugVars ?? string.Empty, s => Program.Config.WineDebugVars = s)
         };

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -9,7 +9,7 @@ namespace XIVLauncher.Core.Components.SettingsPage.Tabs;
 public class SettingsTabWine : SettingsTab
 {
     private SettingsEntry<WineStartupType> startupTypeSetting;
-	private SettingsEntry<Dxvk.DxvkHudType> dxvkOverlaySetting;
+    private SettingsEntry<Dxvk.DxvkHudType> dxvkOverlaySetting;
 
     public SettingsTabWine()
     {

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -52,7 +52,13 @@ public class SettingsTabWine : SettingsTab
                 }
             },
 
-            new SettingsEntry<Dxvk.DxvkHudType>("DXVK Overlay", "Configure how much of the DXVK overlay is to be shown.", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type),
+            dxvkOverlaySetting = new SettingsEntry<Dxvk.DxvkHudType>("DXVK Overlay", "Configure how much of the DXVK overlay is to be shown.", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type),
+			new SettingsEntry<string>("DXVK custom Overlay",
+                "Custom DXVK Overlay string. For example fps,frametimes,gpuload,version",
+                () => Program.Config.DxvkHudCustomString, s => Program.Config.DxvkHudCustomString = s)
+            {
+                CheckVisibility = () => dxvkOverlaySetting.Value == DxvkHudType.Custom
+            },
             new SettingsEntry<string>("WINEDEBUG Variables", "Configure debug logging for wine. Useful for troubleshooting.", () => Program.Config.WineDebugVars ?? string.Empty, s => Program.Config.WineDebugVars = s)
         };
     }

--- a/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
+++ b/src/XIVLauncher.Core/Components/SettingsPage/Tabs/SettingsTabWine.cs
@@ -54,7 +54,7 @@ public class SettingsTabWine : SettingsTab
             },
 
             dxvkOverlaySetting = new SettingsEntry<Dxvk.DxvkHudType>("DXVK Overlay", "Configure how much of the DXVK overlay is to be shown.", () => Program.Config.DxvkHudType, type => Program.Config.DxvkHudType = type),
-			new SettingsEntry<string>("DXVK custom Overlay",
+            new SettingsEntry<string>("DXVK custom Overlay",
                 "Custom DXVK Overlay string. For example fps,frametimes,gpuload,version",
                 () => Program.Config.DxvkHudCustomString, s => Program.Config.DxvkHudCustomString = s)
             {

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -74,7 +74,7 @@ public interface ILauncherConfig
 
     public Dxvk.DxvkHudType DxvkHudType { get; set; }
 
-	public string? DxvkHudCustomString { get; set; }
+    public string? DxvkHudCustomString { get; set; }
 
     public string? WineDebugVars { get; set; }
 

--- a/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
+++ b/src/XIVLauncher.Core/Configuration/ILauncherConfig.cs
@@ -74,6 +74,8 @@ public interface ILauncherConfig
 
     public Dxvk.DxvkHudType DxvkHudType { get; set; }
 
+	public string? DxvkHudCustomString { get; set; }
+
     public string? WineDebugVars { get; set; }
 
     #endregion

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -115,7 +115,7 @@ class Program
         Config.DxvkAsyncEnabled ??= true;
         Config.ESyncEnabled ??= true;
         Config.FSyncEnabled ??= false;
-		Config.DxvkHudCustomString ??= "fps,frametimes,gpuload,version";
+        Config.DxvkHudCustomString ??= "fps,frametimes,gpuload,version";
 
         Config.WineStartupType ??= WineStartupType.Managed;
         Config.WineBinaryPath ??= "/usr/bin";

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -115,6 +115,7 @@ class Program
         Config.DxvkAsyncEnabled ??= true;
         Config.ESyncEnabled ??= true;
         Config.FSyncEnabled ??= false;
+		Config.DxvkHudCustomString ??= "fps,frametimes,gpuload,version";
 
         Config.WineStartupType ??= WineStartupType.Managed;
         Config.WineBinaryPath ??= "/usr/bin";
@@ -276,7 +277,7 @@ class Program
     {
         var wineLogFile = new FileInfo(Path.Combine(storage.GetFolder("logs").FullName, "wine.log"));
         var winePrefix = storage.GetFolder("wineprefix");
-        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
+        var wineSettings = new WineSettings(Config.WineStartupType, Config.WineBinaryPath, Config.DxvkHudCustomString, Config.WineDebugVars, wineLogFile, winePrefix, Config.ESyncEnabled, Config.FSyncEnabled);
         var toolsFolder = storage.GetFolder("compatibilitytool");
         CompatibilityTools = new CompatibilityTools(wineSettings, Config.DxvkHudType, Config.GameModeEnabled, Config.DxvkAsyncEnabled, toolsFolder);
     }


### PR DESCRIPTION
I basically have no idea what I am doing (dotnet?), if there is anything you would like to be changed let me know. 

The current options for DXVK_HUD were not enough so I implemented custom switch for it.

![image](https://user-images.githubusercontent.com/1747330/186653361-182c1d1f-2a07-4810-bd8a-83cd5004c15a.png)
![image](https://user-images.githubusercontent.com/1747330/186652562-27590bd9-753c-4c59-bc3e-c266a71dcfe3.png)
Only visible when set to custom:
![image](https://user-images.githubusercontent.com/1747330/186652585-8df0ddd6-2828-42fe-b933-f3970c77cd8e.png)

Result in game:
![image](https://user-images.githubusercontent.com/1747330/186652709-c1ad8aa3-7adb-4fa2-9d83-28fe8e37ab3e.png)

Tested on: arch
build with customized: https://aur.archlinux.org/packages/xivlauncher-git