### PR TITLE
Add .vscode and build directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -278,7 +278,13 @@ paket-files/
 .idea/
 *.sln.iml
 
+# Visual Studio Code
+.vscode/
+
 # XL Debug dirs
 src/XIVLauncher/XIVLauncher/app-*
 src/XIVLauncher/XIVLauncher
 src/Update.exe
+
+# XLCore build directory
+src/XIVLauncher.Core/build


### PR DESCRIPTION
I use Visual Studio Code under Linux to build XIVLauncher Core, and it creates some directories that should be ignored by git. I've added them to .gitignore.