### PR TITLE
feat: allow dragging the Dalamud overlay

### DIFF
--- a/src/XIVLauncher/Windows/DalamudLoadingOverlay.xaml.cs
+++ b/src/XIVLauncher/Windows/DalamudLoadingOverlay.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Timers;
 using System.Windows;
+using System.Windows.Input;
 using CheapLoc;
 using XIVLauncher.Common.PlatformAbstractions;
 using XIVLauncher.Common.Util;
@@ -129,6 +130,12 @@ namespace XIVLauncher.Windows
         {
             base.OnClosed(e);
             IsClosed = true;
+        }
+
+        protected override void OnMouseLeftButtonDown(MouseButtonEventArgs e)
+        {
+            base.OnMouseLeftButtonDown(e);
+            this.DragMove();
         }
     }
 }


### PR DESCRIPTION
Doesn't save the new position, just allows moving it out of the way for that window instance.