### PR TITLE
XLCore logging adjustments

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -52,6 +52,8 @@ public class MainPage : Page
 
         if (PlatformHelpers.IsElevated())
             App.ShowMessage("XIVLauncher is running as administrator/root user.\nThis can cause various issues, including but not limited to addons failing to launch and hotkey applications failing to respond.\n\nPlease take care to avoid running XIVLauncher with elevated privileges", "XIVLauncher");
+
+        Troubleshooting.LogTroubleshooting(app);
     }
 
     public AccountSwitcher AccountSwitcher { get; private set; }
@@ -618,6 +620,8 @@ public class MainPage : Page
             default:
                 throw new NotImplementedException();
         }
+
+        Troubleshooting.LogTroubleshooting(App);
 
         var dalamudLauncher = new DalamudLauncher(dalamudRunner, Program.DalamudUpdater, App.Settings.DalamudLoadMethod.GetValueOrDefault(DalamudLoadMethod.DllInject),
             App.Settings.GamePath, App.Storage.Root, App.Settings.ClientLanguage ?? ClientLanguage.English, App.Settings.DalamudLoadDelay, false, false, noThird,

--- a/src/XIVLauncher.Core/Program.cs
+++ b/src/XIVLauncher.Core/Program.cs
@@ -64,12 +64,16 @@ class Program
     private static void SetupLogging()
     {
         Log.Logger = new LoggerConfiguration()
-                     .WriteTo.Async(a =>
-                         a.File(Path.Combine(storage.GetFolder("logs").FullName, "launcher.log")))
-                     .WriteTo.Console()
-                     .WriteTo.Debug()
-                     .MinimumLevel.Verbose()
-                     .CreateLogger();
+             .WriteTo.Async(a =>
+                 a.File(Path.Combine(storage.GetFolder("logs").FullName, "launcher.log")))
+             .WriteTo.Console()
+#if DEBUG
+             .WriteTo.Debug()
+             .MinimumLevel.Verbose()
+#else
+             .MinimumLevel.Information()
+#endif
+             .CreateLogger();
 
         Log.Information("========================================================");
         Log.Information("Starting a session(v{Version} - {Hash})", AppUtil.GetAssemblyVersion(), AppUtil.GetGitHash());

--- a/src/XIVLauncher.Core/Support/Troubleshooting.cs
+++ b/src/XIVLauncher.Core/Support/Troubleshooting.cs
@@ -47,6 +47,22 @@ namespace XIVLauncher.Core.Support
             }
         }
 
+        /// <summary>
+        /// Log troubleshooting information in a parseable format to Serilog.
+        /// </summary>
+        internal static void LogTroubleshooting(LauncherApp app)
+        {
+            try
+            {
+                var encodedPayload = Convert.ToBase64String(Encoding.UTF8.GetBytes(GetTroubleshootingJson(app)));
+                Log.Information($"TROUBLESHXLTING:{encodedPayload}");
+            }
+            catch (Exception ex)
+            {
+                Log.Error(ex, "Could not print troubleshooting");
+            }
+        }
+
         internal static string GetTroubleshootingJson(LauncherApp app)
         {
             var gamePath = app.Settings.GamePath;


### PR DESCRIPTION
- Set xlcore to log to information by default in release builds. 
- Adds troubleshooting blobs in mostly the same places as XIVLauncher.Windows