### PR TITLE
Dasset deserialize fallback

### DIFF
--- a/src/XIVLauncher.Common/Dalamud/AssetManager.cs
+++ b/src/XIVLauncher.Common/Dalamud/AssetManager.cs
@@ -151,7 +151,30 @@ namespace XIVLauncher.Common.Dalamud
                 Log.Error(ex, "[DASSET] Could not read asset.ver");
             }
 
-            var remoteVer = JsonConvert.DeserializeObject<AssetInfo>(client.DownloadString(ASSET_STORE_URL));
+            AssetInfo remoteVer = null; ;
+            string assetJson = client.DownloadString(ASSET_STORE_URL);
+            
+#if DEBUG
+            Log.Debug(assetJson, "[DASSET DEBUG] Printing entire asset json");
+#endif
+
+            try
+            {
+                remoteVer = JsonConvert.DeserializeObject<AssetInfo>(client.DownloadString(ASSET_STORE_URL));
+            }
+            catch (JsonSerializationException jse)
+            {
+#if DEBUG
+                Log.Error(jse, "[DASSET DEBUG] Count not deserialize json.");
+#endif
+                Log.Information("DASSET] Using System.Text.Json as fallback to deserialize.");
+                var options = new System.Text.Json.JsonSerializerOptions
+                {
+                    PropertyNameCaseInsensitive = true
+                };
+                remoteVer = System.Text.Json.JsonSerializer.Deserialize<AssetInfo>(assetJson, options);
+            }
+            
 
             Log.Verbose("[DASSET] Ver check - local:{0} remote:{1}", localVer, remoteVer.Version);
 

--- a/src/XIVLauncher.Common/Game/IntegrityCheck.cs
+++ b/src/XIVLauncher.Common/Game/IntegrityCheck.cs
@@ -115,7 +115,7 @@ namespace XIVLauncher.Common.Game
 
 
 #if DEBUG
-                Log.Debug($"{relativePath} swapping to {relativePath.Replace("/", "\\")}");
+                // Log.Debug($"{relativePath} swapping to {relativePath.Replace("/", "\\")}");
 #endif
                 // for unix compatibility with windows-generated integrity files.
                 relativePath = relativePath.Replace("/", "\\");

--- a/src/XIVLauncher.Common/XIVLauncher.Common.csproj
+++ b/src/XIVLauncher.Common/XIVLauncher.Common.csproj
@@ -52,5 +52,6 @@
         <PackageReference Include="SharedMemory" Version="2.3.2" />
         <PackageReference Include="System.Memory" Version="4.5.4" />
         <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
+        <PackageReference Include="System.Text.Json" Version="6.0.5" />
     </ItemGroup>
 </Project>

--- a/src/XIVLauncher/XIVLauncher.csproj
+++ b/src/XIVLauncher/XIVLauncher.csproj
@@ -87,7 +87,7 @@
     <PackageReference Include="SharedMemory" Version="2.3.2" />
     <PackageReference Include="squirrel.windows" Version="1.9.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="4.7.2" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Use System.Text.Json as a fallback in the handful of weird cases we've seen where Newtonsoft.Json fails. This is a super rare occurrence and most users shouldn't need it.