### PR TITLE
Allow use of WineD3D with environment variable. (Linux)

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -156,6 +156,17 @@ public class CompatibilityTools
         psi.UseShellExecute = false;
         psi.WorkingDirectory = workingDirectory;
 
+        // Environment variable USE_WINED3D can be used to set wineD3D
+        string useWineD3D = Environment.GetEnvironmentVariable("USE_WINED3D") ?? "";
+        if (useWineD3D.Equals("1") || useWineD3D.ToLower().Equals("true"))
+        {
+            wineD3D = true;
+        }
+        else if (useWineD3D.Equals("0") || useWineD3D.ToLower().Equals("false"))
+        {
+            wineD3D = false;
+        }
+
         var wineEnviromentVariables = new Dictionary<string, string>();
         wineEnviromentVariables.Add("WINEPREFIX", Settings.Prefix.FullName);
         wineEnviromentVariables.Add("WINEDLLOVERRIDES", $"mscoree=n;d3d9,d3d11,d3d10core,dxgi={(wineD3D ? "b" : "n")}");


### PR DESCRIPTION
This is a simple patch to allow the use of WineD3D instead of Vulkan. The USE_WINED3D environment variable can be passed to explicitly enable or disable WINED3D. The latter is useless at the moment, but perhaps in the future WineD3D will be included as a setting in the UI, so I put in code to deal with it. Valid values are 0 or false to disable, 1 or true to enable.

Usage example in Steam: `USE_WINED3D=1 %command% --parent-expose-pids --parent-share-pids --parent-pid=1`

I don't know how to build the flatpak, so I haven't been able to test that, but it works fine with a native build. Performance isn't terribly good on an AMD 6700XT, but it might work better for nVidia or Intel. It might also provide a solution if someone is trying to use an older graphics card that doesn't support Vulkan.

Here's a screenshot using mangohud to prove it's running:
![WineD3D_working](https://user-images.githubusercontent.com/109918887/193950270-dad1814a-995f-499d-a6ac-92faac7293df.jpg)
