### PR TITLE
Fix game starting with "Update without starting" when a patch is installed

### DIFF
--- a/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
+++ b/src/XIVLauncher.Core/Components/MainPage/MainPage.cs
@@ -317,7 +317,6 @@ public class MainPage : Page
                         return false;
 
                     loginResult.State = Launcher.LoginState.Ok;
-                    action = LoginAction.Game;
                 }
                 else
                 {
@@ -355,7 +354,6 @@ public class MainPage : Page
             }
 
             loginResult.State = Launcher.LoginState.Ok;
-            action = LoginAction.Game;
         }
 
         if (action == LoginAction.GameNoLaunch)

--- a/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
@@ -541,7 +541,6 @@ namespace XIVLauncher.Windows.ViewModel
                             return false;
 
                         loginResult.State = Launcher.LoginState.Ok;
-                        action = AfterLoginAction.Start;
                     }
                     else
                     {
@@ -586,7 +585,6 @@ namespace XIVLauncher.Windows.ViewModel
                 }
 
                 loginResult.State = Launcher.LoginState.Ok;
-                action = AfterLoginAction.Start;
             }
 
             if (action == AfterLoginAction.UpdateOnly)


### PR DESCRIPTION
Overriding action after a patch is successfully installed breaks the UpdateOnly action which is checked for just below. The override is unnecessary because all other actions except UpdateOnly fall through into game start block anyway, so it can be simply removed. Also remove similar override after successful repair, as it is similarly unnecessary even though it does not change behavior.