### PR TITLE
(Linux) Add a XL_FORCE_WINED3D variable, and fix a crash with bad env variable values

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -156,6 +156,10 @@ public class CompatibilityTools
         psi.UseShellExecute = false;
         psi.WorkingDirectory = workingDirectory;
 
+        if (EnvironmentSettings.IsWineD3D) {
+            wineD3D = true;
+        }
+        
         var wineEnviromentVariables = new Dictionary<string, string>();
         wineEnviromentVariables.Add("WINEPREFIX", Settings.Prefix.FullName);
         wineEnviromentVariables.Add("WINEDLLOVERRIDES", $"mscoree=n;d3d9,d3d11,d3d10core,dxgi={(wineD3D ? "b" : "n")}");

--- a/src/XIVLauncher.Common/EnvironmentSettings.cs
+++ b/src/XIVLauncher.Common/EnvironmentSettings.cs
@@ -9,6 +9,10 @@
         public static bool IsNoRunas => CheckEnvBool("XL_NO_RUNAS");
         public static bool IsIgnoreSpaceRequirements => CheckEnvBool("XL_NO_SPACE_REQUIREMENTS");
         public static bool IsWineD3D => CheckEnvBool("XL_FORCE_WINED3D");
-        private static bool CheckEnvBool(string var) => bool.Parse(System.Environment.GetEnvironmentVariable(var) ?? "false");
+        private static bool CheckEnvBool(string var)
+        {
+            var = (System.Environment.GetEnvironmentVariable(var) ?? "false").ToLower();
+            return (var.Equals("1") || var.Equals("true") || var.Equals("on") || var.Equals("yes"));
+        }
     }
 }

--- a/src/XIVLauncher.Common/EnvironmentSettings.cs
+++ b/src/XIVLauncher.Common/EnvironmentSettings.cs
@@ -8,6 +8,7 @@
         public static bool IsPreRelease => CheckEnvBool("XL_PRERELEASE");
         public static bool IsNoRunas => CheckEnvBool("XL_NO_RUNAS");
         public static bool IsIgnoreSpaceRequirements => CheckEnvBool("XL_NO_SPACE_REQUIREMENTS");
+        public static bool IsWineD3D => CheckEnvBool("XL_FORCE_WINED3D");
         private static bool CheckEnvBool(string var) => bool.Parse(System.Environment.GetEnvironmentVariable(var) ?? "false");
     }
 }


### PR DESCRIPTION
Two changes:
1. Add an environment variable, XL_FORCE_WINED3D, to force the use of wined3d instead of dxvk. Name changed due to suggestion by marzent 
2. Change the function for CheckEnvBool(). Currently, it will crash the launcher if you set one of the XL environment variables to something other than "true" or "false" or nothing. So XL_WINEONLINUX=1 will crash. This patch will now make CheckEnvBool() evaluate to true with values of true, 1, on, and yes. Everything else will evaluate to false, allowing the launcher to ignore bad values instead of crashing.