### PR TITLE
fix: allow xlcore to build

### DIFF
--- a/src/XIVLauncher.Common/Game/Launcher.cs
+++ b/src/XIVLauncher.Common/Game/Launcher.cs
@@ -40,7 +40,7 @@ public class Launcher
 
     private const string FALLBACK_FRONTIER_URL_TEMPLATE = "https://launcher.finalfantasyxiv.com/v620/index.html?rc_lang={0}&time={1}";
 
-    public Launcher(ISteam? steam, IUniqueIdCache uniqueIdCache, ISettings settings, string? frontierUrl)
+    public Launcher(ISteam? steam, IUniqueIdCache uniqueIdCache, ISettings settings, string? frontierUrl =  null)
     {
         this.steam = steam;
         this.uniqueIdCache = uniqueIdCache;
@@ -71,7 +71,7 @@ public class Launcher
         this.client = new HttpClient(handler);
     }
 
-    public Launcher(byte[] steamTicket, IUniqueIdCache uniqueIdCache, ISettings settings, string? frontierUrl)
+    public Launcher(byte[] steamTicket, IUniqueIdCache uniqueIdCache, ISettings settings, string? frontierUrl = null)
         : this(steam: null, uniqueIdCache, settings, frontierUrl)
     {
         this.steamTicket = steamTicket;


### PR DESCRIPTION
XL Core will not currently build. Need to update either the LauncherApp.cs in XL Core (see [PR #12](https://github.com/goatcorp/XIVLauncher.Core/pull/12)) or this. Both together also work.
* A 4th arg was added to constructor of Launcher class
* XL Core only knows about 3 args. Setting default to null allows build.

This was part of my dxvk settings rework, but was removed from there for being out of scope.