### PR TITLE
Conversion to `System.Text.Json`

### DIFF
--- a/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
@@ -4,7 +4,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Serilog;
 using XIVLauncher.Common.Dalamud;
 using XIVLauncher.Common.PlatformAbstractions;
@@ -94,7 +94,7 @@ public class UnixDalamudRunner : IDalamudRunner
 
         try
         {
-            var dalamudConsoleOutput = JsonConvert.DeserializeObject<DalamudConsoleOutput>(output);
+            var dalamudConsoleOutput = JsonSerializer.Deserialize<DalamudConsoleOutput>(output);
             var unixPid = compatibility.GetUnixProcessId(dalamudConsoleOutput.Pid);
 
             if (unixPid == 0)
@@ -107,7 +107,7 @@ public class UnixDalamudRunner : IDalamudRunner
             Log.Verbose($"Got game process handle {gameProcess.Handle} with Unix pid {gameProcess.Id} and Wine pid {dalamudConsoleOutput.Pid}");
             return gameProcess;
         }
-        catch (JsonReaderException ex)
+        catch (JsonException ex)
         {
             Log.Error(ex, $"Couldn't parse Dalamud output: {output}");
             return null;

--- a/src/XIVLauncher.Common.Windows/WindowsDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Windows/WindowsDalamudRunner.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Runtime.InteropServices;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Serilog;
 using XIVLauncher.Common.Dalamud;
 using XIVLauncher.Common.PlatformAbstractions;
@@ -72,7 +72,7 @@ public class WindowsDalamudRunner : IDalamudRunner
 
             try
             {
-                var dalamudConsoleOutput = JsonConvert.DeserializeObject<DalamudConsoleOutput>(output);
+                var dalamudConsoleOutput = JsonSerializer.Deserialize<DalamudConsoleOutput>(output);
                 Process gameProcess;
 
                 if (dalamudConsoleOutput.Handle == 0)
@@ -101,7 +101,7 @@ public class WindowsDalamudRunner : IDalamudRunner
 
                 return gameProcess;
             }
-            catch (JsonReaderException ex)
+            catch (JsonException ex)
             {
                 Log.Error(ex, $"Couldn't parse Dalamud output: {output}");
                 return null;

--- a/src/XIVLauncher.Common/CommonUniqueIdCache.cs
+++ b/src/XIVLauncher.Common/CommonUniqueIdCache.cs
@@ -2,7 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using XIVLauncher.Common.PlatformAbstractions;
 
 namespace XIVLauncher.PlatformAbstractions
@@ -24,10 +25,8 @@ namespace XIVLauncher.PlatformAbstractions
 
         private readonly FileInfo configFile;
 
-        public void Save()
-        {
-            File.WriteAllText(configFile.FullName, JsonConvert.SerializeObject(_cache, Formatting.Indented));
-        }
+        public void Save() =>
+            File.WriteAllText(configFile.FullName, JsonSerializer.Serialize(_cache, new JsonSerializerOptions { WriteIndented = true }));
 
         public void Load()
         {
@@ -37,7 +36,7 @@ namespace XIVLauncher.PlatformAbstractions
                 return;
             }
 
-            _cache = JsonConvert.DeserializeObject<List<UniqueIdCacheEntry>>(File.ReadAllText(configFile.FullName)) ?? new List<UniqueIdCacheEntry>();
+            _cache = JsonSerializer.Deserialize<List<UniqueIdCacheEntry>>(File.ReadAllText(configFile.FullName)) ?? new List<UniqueIdCacheEntry>();
         }
 
         public void Reset()

--- a/src/XIVLauncher.Common/Dalamud/DalamudConsoleOutput.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudConsoleOutput.cs
@@ -1,13 +1,13 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace XIVLauncher.Common.Dalamud
 {
     public sealed class DalamudConsoleOutput
     {
-        [JsonProperty("pid")]
+        [JsonPropertyName("pid")]
         public int Pid { get; set; }
 
-        [JsonProperty("handle")]
+        [JsonPropertyName("handle")]
         public long Handle { get; set; }
     }
 }

--- a/src/XIVLauncher.Common/Dalamud/DalamudLauncher.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudLauncher.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Net;
 using System.Threading;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Serilog;
 using XIVLauncher.Common.PlatformAbstractions;
 
@@ -159,7 +159,7 @@ namespace XIVLauncher.Common.Dalamud
             using var client = new WebClient();
 
             var versionInfoJson = client.DownloadString(REMOTE_BASE + "release");
-            var remoteVersionInfo = JsonConvert.DeserializeObject<DalamudVersionInfo>(versionInfoJson);
+            var remoteVersionInfo = JsonSerializer.Deserialize<DalamudVersionInfo>(versionInfoJson);
 
             if (Repository.Ffxiv.GetVer(gamePath) != remoteVersionInfo.SupportedGameVer)
                 return false;

--- a/src/XIVLauncher.Common/Dalamud/DalamudSettings.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudSettings.cs
@@ -1,6 +1,6 @@
 using System;
 using System.IO;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Serilog;
 
 namespace XIVLauncher.Common.Dalamud
@@ -20,7 +20,7 @@ namespace XIVLauncher.Common.Dalamud
 
             try
             {
-                deserialized = File.Exists(configPath) ? JsonConvert.DeserializeObject<DalamudSettings>(File.ReadAllText(configPath)) : new DalamudSettings();
+                deserialized = File.Exists(configPath) ? JsonSerializer.Deserialize<DalamudSettings>(File.ReadAllText(configPath)) : new DalamudSettings();
             }
             catch (Exception ex)
             {

--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
@@ -8,7 +8,7 @@ using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Security.Cryptography;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Serilog;
 using XIVLauncher.Common.PlatformAbstractions;
 using XIVLauncher.Common.Util;
@@ -142,7 +142,7 @@ namespace XIVLauncher.Common.Dalamud
 
             var versionInfoJsonRelease = await client.GetStringAsync(DalamudLauncher.REMOTE_BASE + $"release&bucket={this.RolloutBucket}").ConfigureAwait(false);
 
-            DalamudVersionInfo versionInfoRelease = JsonConvert.DeserializeObject<DalamudVersionInfo>(versionInfoJsonRelease);
+            DalamudVersionInfo versionInfoRelease = JsonSerializer.Deserialize<DalamudVersionInfo>(versionInfoJsonRelease);
 
             DalamudVersionInfo? versionInfoStaging = null;
 
@@ -151,7 +151,7 @@ namespace XIVLauncher.Common.Dalamud
                 var versionInfoJsonStaging = await client.GetAsync(DalamudLauncher.REMOTE_BASE + GetBetaTrackName(settings)).ConfigureAwait(false);
 
                 if (versionInfoJsonStaging.StatusCode != HttpStatusCode.BadRequest)
-                    versionInfoStaging = JsonConvert.DeserializeObject<DalamudVersionInfo>(await versionInfoJsonStaging.Content.ReadAsStringAsync().ConfigureAwait(false));
+                    versionInfoStaging = JsonSerializer.Deserialize<DalamudVersionInfo>(await versionInfoJsonStaging.Content.ReadAsStringAsync().ConfigureAwait(false));
             }
 
             return (versionInfoRelease, versionInfoStaging);
@@ -179,7 +179,7 @@ namespace XIVLauncher.Common.Dalamud
                 Log.Information("[DUPDATE] Using release version ({Hash})", remoteVersionInfo.AssemblyVersion);
             }
 
-            var versionInfoJson = JsonConvert.SerializeObject(remoteVersionInfo);
+            var versionInfoJson = JsonSerializer.Serialize(remoteVersionInfo);
 
             var addonPath = new DirectoryInfo(Path.Combine(this.addonDirectory.FullName, "Hooks"));
             var currentVersionPath = new DirectoryInfo(Path.Combine(addonPath.FullName, remoteVersionInfo.AssemblyVersion));
@@ -331,7 +331,7 @@ namespace XIVLauncher.Common.Dalamud
             {
                 Log.Verbose("[DUPDATE] Checking integrity of {Directory}", directory.FullName);
 
-                var hashes = JsonConvert.DeserializeObject<Dictionary<string, string>>(hashesJson);
+                var hashes = JsonSerializer.Deserialize<Dictionary<string, string>>(hashesJson);
 
                 foreach (var hash in hashes)
                 {

--- a/src/XIVLauncher.Common/Dalamud/DalamudVersionInfo.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudVersionInfo.cs
@@ -1,18 +1,30 @@
 ﻿using System.IO;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 
 namespace XIVLauncher.Common.Dalamud
 {
     internal class DalamudVersionInfo
     {
+        [JsonPropertyName("assemblyVersion")]
         public string AssemblyVersion { get; set; }
+        
+        [JsonPropertyName("supportedGameVer")]
         public string SupportedGameVer { get; set; }
+        
+        [JsonPropertyName("runtimeVersion")]
         public string RuntimeVersion { get; set; }
+        
+        [JsonPropertyName("runtimeRequired")]
         public bool RuntimeRequired { get; set; }
+        
+        [JsonPropertyName("key")]
         public string Key { get; set; }
+        
+        [JsonPropertyName("downloadUrl")]
         public string DownloadUrl { get; set; }
 
         public static DalamudVersionInfo Load(FileInfo file) =>
-            JsonConvert.DeserializeObject<DalamudVersionInfo>(File.ReadAllText(file.FullName));
+            JsonSerializer.Deserialize<DalamudVersionInfo>(File.ReadAllText(file.FullName));
     }
 }

--- a/src/XIVLauncher.Common/Game/GateStatus.cs
+++ b/src/XIVLauncher.Common/Game/GateStatus.cs
@@ -1,16 +1,16 @@
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace XIVLauncher.Common.Game;
 
 public class GateStatus
 {
-    [JsonProperty("status")]
+    [JsonPropertyName("status")]
     public bool Status { get; set; }
 
-    [JsonProperty("message")]
+    [JsonPropertyName("message")]
     public List<string> Message { get; set; }
 
-    [JsonProperty("news")]
+    [JsonPropertyName("news")]
     public List<string> News { get; set; }
 }

--- a/src/XIVLauncher.Common/Game/Headlines.cs
+++ b/src/XIVLauncher.Common/Game/Headlines.cs
@@ -2,51 +2,52 @@
 using System.Globalization;
 using System.Text;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Converters;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using XIVLauncher.Common.Util;
 
 namespace XIVLauncher.Common.Game
 {
     public partial class Headlines
     {
-        [JsonProperty("news")]
+        [JsonPropertyName("news")]
         public News[] News { get; set; }
 
-        [JsonProperty("topics")]
+        [JsonPropertyName("topics")]
         public News[] Topics { get; set; }
 
-        [JsonProperty("pinned")]
+        [JsonPropertyName("pinned")]
         public News[] Pinned { get; set; }
 
-        [JsonProperty("banner")]
+        [JsonPropertyName("banner")]
         public Banner[] Banner { get; set; }
     }
 
     public class Banner
     {
-        [JsonProperty("lsb_banner")]
+        [JsonPropertyName("lsb_banner")]
         public Uri LsbBanner { get; set; }
 
-        [JsonProperty("link")]
+        [JsonPropertyName("link")]
         public Uri Link { get; set; }
     }
 
     public class News
     {
-        [JsonProperty("date")]
+        [JsonPropertyName("date")]
         public DateTimeOffset Date { get; set; }
 
-        [JsonProperty("title")]
+        [JsonPropertyName("title")]
         public string Title { get; set; }
 
-        [JsonProperty("url")]
+        [JsonPropertyName("url")]
         public string Url { get; set; }
 
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public string Id { get; set; }
 
-        [JsonProperty("tag", NullValueHandling = NullValueHandling.Ignore)]
+        [JsonPropertyName("tag")]
+        [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
         public string Tag { get; set; }
     }
 
@@ -60,20 +61,7 @@ namespace XIVLauncher.Common.Game
 
             var json = Encoding.UTF8.GetString(await game.DownloadAsLauncher(url, language, "application/json, text/plain, */*").ConfigureAwait(false));
 
-            return JsonConvert.DeserializeObject<Headlines>(json, Converter.SETTINGS);
+            return JsonSerializer.Deserialize<Headlines>(json);
         }
-    }
-
-    internal static class Converter
-    {
-        public static readonly JsonSerializerSettings SETTINGS = new JsonSerializerSettings
-        {
-            MetadataPropertyHandling = MetadataPropertyHandling.Ignore,
-            DateParseHandling = DateParseHandling.None,
-            Converters =
-            {
-                new IsoDateTimeConverter { DateTimeStyles = DateTimeStyles.AssumeUniversal }
-            }
-        };
     }
 }

--- a/src/XIVLauncher.Common/Game/Launcher.cs
+++ b/src/XIVLauncher.Common/Game/Launcher.cs
@@ -19,7 +19,7 @@ using System.Security.Cryptography;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Serilog;
 using XIVLauncher.Common.Game.Patch.PatchList;
 using XIVLauncher.Common.Encryption;
@@ -609,7 +609,7 @@ public class Launcher
                 await DownloadAsLauncher(
                     $"https://frontier.ffxiv.com/worldStatus/gate_status.json?lang={language.GetLangCode()}&_={ApiHelpers.GetUnixMillis()}", language).ConfigureAwait(true));
 
-            return JsonConvert.DeserializeObject<GateStatus>(reply);
+            return JsonSerializer.Deserialize<GateStatus>(reply);
         }
         catch (Exception exc)
         {

--- a/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaFile.cs
+++ b/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaFile.cs
@@ -4,28 +4,28 @@
  */
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace AriaNet.Attributes
 {
     public class AriaFile
     {
-        [JsonProperty("index")]
+        [JsonPropertyName("index")]
         public string Index { get; set; }
 
-        [JsonProperty("length")]
+        [JsonPropertyName("length")]
         public string Length { get; set; }
 
-        [JsonProperty("completedLength")]
+        [JsonPropertyName("completedLength")]
         public string CompletedLength { get; set; }
 
-        [JsonProperty("path")]
+        [JsonPropertyName("path")]
         public string Path { get; set; }
 
-        [JsonProperty("selected")]
+        [JsonPropertyName("selected")]
         public string Selected { get; set; }
 
-        [JsonProperty("uris")]
+        [JsonPropertyName("uris")]
         public List<AriaUri> Uris { get; set; }
     }
 }

--- a/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaGlobalStatus.cs
+++ b/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaGlobalStatus.cs
@@ -3,26 +3,25 @@
  * You can find the original code in this GitHub repository: https://github.com/huming2207/AriaNet
  */
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace AriaNet.Attributes
 {
-    [JsonObject]
     public class AriaGlobalStatus
     {
-        [JsonProperty("downloadSpeed")]
+        [JsonPropertyName("downloadSpeed")]
         public int DownloadSpeed { get; set; }
-        
-        [JsonProperty("numActive")]
+
+        [JsonPropertyName("numActive")]
         public int ActiveTaskCount { get; set; }
-        
-        [JsonProperty("numStopped")]
+
+        [JsonPropertyName("numStopped")]
         public int StoppedTaskCount { get; set; }
-        
-        [JsonProperty("numWaiting")]
+
+        [JsonPropertyName("numWaiting")]
         public int WaitingTaskCount { get; set; }
-        
-        [JsonProperty("uploadSpeed")]
+
+        [JsonPropertyName("uploadSpeed")]
         public int UploadSpeed { get; set; }
     }
 }

--- a/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaOption.cs
+++ b/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaOption.cs
@@ -3,338 +3,337 @@
  * You can find the original code in this GitHub repository: https://github.com/huming2207/AriaNet
  */
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace AriaNet.Attributes
 {
-    [JsonObject]
     public class AriaOption
     {
-        [JsonProperty("all-proxy")]
+        [JsonPropertyName("all-proxy")]
         public string AllProxy { get; set; }
 
-        [JsonProperty("all-proxy-passwd")]
+        [JsonPropertyName("all-proxy-passwd")]
         public string AllProxyPasswd { get; set; }
 
-        [JsonProperty("all-proxy-user")]
+        [JsonPropertyName("all-proxy-user")]
         public string AllProxyUser { get; set; }
 
-        [JsonProperty("allow-overwrite")]
+        [JsonPropertyName("allow-overwrite")]
         public string AllowOverwrite { get; set; }
 
-        [JsonProperty("allow-piece-length-change")]
+        [JsonPropertyName("allow-piece-length-change")]
         public string AllowPieceLengthChange { get; set; }
 
-        [JsonProperty("always-resume")]
+        [JsonPropertyName("always-resume")]
         public string AlwaysResume { get; set; }
 
-        [JsonProperty("async-dns")]
+        [JsonPropertyName("async-dns")]
         public string AsyncDns { get; set; }
 
-        [JsonProperty("auto-file-renaming")]
+        [JsonPropertyName("auto-file-renaming")]
         public string AutoFileRenaming { get; set; }
 
-        [JsonProperty("bt-enable-hook-after-hash-check")]
+        [JsonPropertyName("bt-enable-hook-after-hash-check")]
         public string BtEnableHookAfterHashCheck { get; set; }
 
-        [JsonProperty("bt-enable-lpd")]
+        [JsonPropertyName("bt-enable-lpd")]
         public string BtEnableLpd { get; set; }
 
-        [JsonProperty("bt-exclude-tracker")]
+        [JsonPropertyName("bt-exclude-tracker")]
         public string BtExcludeTracker { get; set; }
 
-        [JsonProperty("bt-external-ip")]
+        [JsonPropertyName("bt-external-ip")]
         public string BtExternalIp { get; set; }
 
-        [JsonProperty("bt-force-encryption")]
+        [JsonPropertyName("bt-force-encryption")]
         public string BtForceEncryption { get; set; }
 
-        [JsonProperty("bt-hash-check-seed")]
+        [JsonPropertyName("bt-hash-check-seed")]
         public string BtHashCheckSeed { get; set; }
 
-        [JsonProperty("bt-max-peers")]
+        [JsonPropertyName("bt-max-peers")]
         public string BtMaxPeers { get; set; }
 
-        [JsonProperty("bt-metadata-only")]
+        [JsonPropertyName("bt-metadata-only")]
         public string BtMetadataOnly { get; set; }
 
-        [JsonProperty("bt-min-crypto-level")]
+        [JsonPropertyName("bt-min-crypto-level")]
         public string BtMinCryptoLevel { get; set; }
 
-        [JsonProperty("bt-prioritize-piece")]
+        [JsonPropertyName("bt-prioritize-piece")]
         public string BtPrioritizePiece { get; set; }
 
-        [JsonProperty("bt-remove-unselected-file")]
+        [JsonPropertyName("bt-remove-unselected-file")]
         public string BtRemoveUnselectedFile { get; set; }
 
-        [JsonProperty("bt-request-peer-speed-limit")]
+        [JsonPropertyName("bt-request-peer-speed-limit")]
         public string BtRequestPeerSpeedLimit { get; set; }
 
-        [JsonProperty("bt-require-crypto")]
+        [JsonPropertyName("bt-require-crypto")]
         public string BtRequireCrypto { get; set; }
 
-        [JsonProperty("bt-save-metadata")]
+        [JsonPropertyName("bt-save-metadata")]
         public string BtSaveMetadata { get; set; }
 
-        [JsonProperty("bt-seed-unverified")]
+        [JsonPropertyName("bt-seed-unverified")]
         public string BtSeedUnverified { get; set; }
 
-        [JsonProperty("bt-stop-timeout")]
+        [JsonPropertyName("bt-stop-timeout")]
         public string BtStopTimeout { get; set; }
 
-        [JsonProperty("bt-tracker")]
+        [JsonPropertyName("bt-tracker")]
         public string BtTracker { get; set; }
 
-        [JsonProperty("bt-tracker-connect-timeout")]
+        [JsonPropertyName("bt-tracker-connect-timeout")]
         public string BtTrackerConnectTimeout { get; set; }
 
-        [JsonProperty("bt-tracker-interval")]
+        [JsonPropertyName("bt-tracker-interval")]
         public string BtTrackerInterval { get; set; }
 
-        [JsonProperty("bt-tracker-timeout")]
+        [JsonPropertyName("bt-tracker-timeout")]
         public string BtTrackerTimeout { get; set; }
 
-        [JsonProperty("check-integrity")]
+        [JsonPropertyName("check-integrity")]
         public string CheckIntegrity { get; set; }
 
-        [JsonProperty("checksum")]
+        [JsonPropertyName("checksum")]
         public string Checksum { get; set; }
 
-        [JsonProperty("conditional-get")]
+        [JsonPropertyName("conditional-get")]
         public string ConditionalGet { get; set; }
 
-        [JsonProperty("connect-timeout")]
+        [JsonPropertyName("connect-timeout")]
         public string ConnectTimeout { get; set; }
 
-        [JsonProperty("content-disposition-default-utf8")]
+        [JsonPropertyName("content-disposition-default-utf8")]
         public string ContentDispositionDefaultUtf8 { get; set; }
 
-        [JsonProperty("continue")]
+        [JsonPropertyName("continue")]
         public string Continue { get; set; }
 
-        [JsonProperty("dir")]
+        [JsonPropertyName("dir")]
         public string Dir { get; set; }
 
-        [JsonProperty("dry-run")]
+        [JsonPropertyName("dry-run")]
         public string DryRun { get; set; }
 
-        [JsonProperty("enable-http-keep-alive")]
+        [JsonPropertyName("enable-http-keep-alive")]
         public string EnableHttpKeepAlive { get; set; }
 
-        [JsonProperty("enable-http-pipelining")]
+        [JsonPropertyName("enable-http-pipelining")]
         public string EnableHttpPipelining { get; set; }
 
-        [JsonProperty("enable-mmap")]
+        [JsonPropertyName("enable-mmap")]
         public string EnableMmap { get; set; }
 
-        [JsonProperty("enable-peer-exchange")]
+        [JsonPropertyName("enable-peer-exchange")]
         public string EnablePeerExchange { get; set; }
 
-        [JsonProperty("file-allocation")]
+        [JsonPropertyName("file-allocation")]
         public string FileAllocation { get; set; }
 
-        [JsonProperty("follow-metalink")]
+        [JsonPropertyName("follow-metalink")]
         public string FollowMetalink { get; set; }
 
-        [JsonProperty("follow-torrent")]
+        [JsonPropertyName("follow-torrent")]
         public string FollowTorrent { get; set; }
 
-        [JsonProperty("force-save")]
+        [JsonPropertyName("force-save")]
         public string ForceSave { get; set; }
 
-        [JsonProperty("ftp-passwd")]
+        [JsonPropertyName("ftp-passwd")]
         public string FtpPasswd { get; set; }
 
-        [JsonProperty("ftp-pasv")]
+        [JsonPropertyName("ftp-pasv")]
         public string FtpPasv { get; set; }
 
-        [JsonProperty("ftp-proxy")]
+        [JsonPropertyName("ftp-proxy")]
         public string FtpProxy { get; set; }
 
-        [JsonProperty("ftp-proxy-passwd")]
+        [JsonPropertyName("ftp-proxy-passwd")]
         public string FtpProxyPasswd { get; set; }
 
-        [JsonProperty("ftp-proxy-user")]
+        [JsonPropertyName("ftp-proxy-user")]
         public string FtpProxyUser { get; set; }
 
-        [JsonProperty("ftp-reuse-connection")]
+        [JsonPropertyName("ftp-reuse-connection")]
         public string FtpReuseConnection { get; set; }
 
-        [JsonProperty("ftp-type")]
+        [JsonPropertyName("ftp-type")]
         public string FtpType { get; set; }
 
-        [JsonProperty("ftp-user")]
+        [JsonPropertyName("ftp-user")]
         public string FtpUser { get; set; }
 
-        [JsonProperty("gid")]
+        [JsonPropertyName("gid")]
         public string Gid { get; set; }
 
-        [JsonProperty("hash-check-only")]
+        [JsonPropertyName("hash-check-only")]
         public string HashCheckOnly { get; set; }
 
-        [JsonProperty("header")]
+        [JsonPropertyName("header")]
         public string Header { get; set; }
 
-        [JsonProperty("http-accept-gzip")]
+        [JsonPropertyName("http-accept-gzip")]
         public string HttpAcceptGzip { get; set; }
 
-        [JsonProperty("http-auth-challenge")]
+        [JsonPropertyName("http-auth-challenge")]
         public string HttpAuthChallenge { get; set; }
 
-        [JsonProperty("http-no-cache")]
+        [JsonPropertyName("http-no-cache")]
         public string HttpNoCache { get; set; }
 
-        [JsonProperty("http-passwd")]
+        [JsonPropertyName("http-passwd")]
         public string HttpPasswd { get; set; }
 
-        [JsonProperty("http-proxy")]
+        [JsonPropertyName("http-proxy")]
         public string HttpProxy { get; set; }
 
-        [JsonProperty("http-proxy-passwd")]
+        [JsonPropertyName("http-proxy-passwd")]
         public string HttpProxyPasswd { get; set; }
 
-        [JsonProperty("http-proxy-user")]
+        [JsonPropertyName("http-proxy-user")]
         public string HttpProxyUser { get; set; }
 
-        [JsonProperty("http-user")]
+        [JsonPropertyName("http-user")]
         public string HttpUser { get; set; }
 
-        [JsonProperty("https-proxy")]
+        [JsonPropertyName("https-proxy")]
         public string HttpsProxy { get; set; }
 
-        [JsonProperty("https-proxy-passwd")]
+        [JsonPropertyName("https-proxy-passwd")]
         public string HttpsProxyPasswd { get; set; }
 
-        [JsonProperty("https-proxy-user")]
+        [JsonPropertyName("https-proxy-user")]
         public string HttpsProxyUser { get; set; }
 
-        [JsonProperty("index-out")]
+        [JsonPropertyName("index-out")]
         public string IndexOut { get; set; }
 
-        [JsonProperty("lowest-speed-limit")]
+        [JsonPropertyName("lowest-speed-limit")]
         public string LowestSpeedLimit { get; set; }
 
-        [JsonProperty("max-connection-per-server")]
+        [JsonPropertyName("max-connection-per-server")]
         public string MaxConnectionPerServer { get; set; }
 
-        [JsonProperty("max-download-limit")]
+        [JsonPropertyName("max-download-limit")]
         public string MaxDownloadLimit { get; set; }
 
-        [JsonProperty("max-file-not-found")]
+        [JsonPropertyName("max-file-not-found")]
         public string MaxFileNotFound { get; set; }
 
-        [JsonProperty("max-mmap-limit")]
+        [JsonPropertyName("max-mmap-limit")]
         public string MaxMmapLimit { get; set; }
 
-        [JsonProperty("max-resume-failure-tries")]
+        [JsonPropertyName("max-resume-failure-tries")]
         public string MaxResumeFailureTries { get; set; }
 
-        [JsonProperty("max-tries")]
+        [JsonPropertyName("max-tries")]
         public string MaxTries { get; set; }
 
-        [JsonProperty("max-upload-limit")]
+        [JsonPropertyName("max-upload-limit")]
         public string MaxUploadLimit { get; set; }
 
-        [JsonProperty("metalink-base-uri")]
+        [JsonPropertyName("metalink-base-uri")]
         public string MetalinkBaseUri { get; set; }
 
-        [JsonProperty("metalink-enable-unique-protocol")]
+        [JsonPropertyName("metalink-enable-unique-protocol")]
         public string MetalinkEnableUniqueProtocol { get; set; }
 
-        [JsonProperty("metalink-language")]
+        [JsonPropertyName("metalink-language")]
         public string MetalinkLanguage { get; set; }
 
-        [JsonProperty("metalink-location")]
+        [JsonPropertyName("metalink-location")]
         public string MetalinkLocation { get; set; }
 
-        [JsonProperty("metalink-os")]
+        [JsonPropertyName("metalink-os")]
         public string MetalinkOs { get; set; }
 
-        [JsonProperty("metalink-preferred-protocol")]
+        [JsonPropertyName("metalink-preferred-protocol")]
         public string MetalinkPreferredProtocol { get; set; }
 
-        [JsonProperty("metalink-version")]
+        [JsonPropertyName("metalink-version")]
         public string MetalinkVersion { get; set; }
 
-        [JsonProperty("min-split-size")]
+        [JsonPropertyName("min-split-size")]
         public string MinSplitSize { get; set; }
 
-        [JsonProperty("no-file-allocation-limit")]
+        [JsonPropertyName("no-file-allocation-limit")]
         public string NoFileAllocationLimit { get; set; }
 
-        [JsonProperty("no-netrc")]
+        [JsonPropertyName("no-netrc")]
         public string NoNetrc { get; set; }
 
-        [JsonProperty("no-proxy")]
+        [JsonPropertyName("no-proxy")]
         public string NoProxy { get; set; }
 
-        [JsonProperty("out")]
+        [JsonPropertyName("out")]
         public string Out { get; set; }
 
-        [JsonProperty("parameterized-uri")]
+        [JsonPropertyName("parameterized-uri")]
         public string ParameterizedUri { get; set; }
 
-        [JsonProperty("pause")]
+        [JsonPropertyName("pause")]
         public string Pause { get; set; }
 
-        [JsonProperty("pause-metadata")]
+        [JsonPropertyName("pause-metadata")]
         public string PauseMetadata { get; set; }
 
-        [JsonProperty("piece-length")]
+        [JsonPropertyName("piece-length")]
         public string PieceLength { get; set; }
 
-        [JsonProperty("proxy-method")]
+        [JsonPropertyName("proxy-method")]
         public string ProxyMethod { get; set; }
 
-        [JsonProperty("realtime-chunk-checksum")]
+        [JsonPropertyName("realtime-chunk-checksum")]
         public string RealtimeChunkChecksum { get; set; }
 
-        [JsonProperty("referer")]
+        [JsonPropertyName("referer")]
         public string Referer { get; set; }
 
-        [JsonProperty("remote-time")]
+        [JsonPropertyName("remote-time")]
         public string RemoteTime { get; set; }
 
-        [JsonProperty("remove-control-file")]
+        [JsonPropertyName("remove-control-file")]
         public string RemoveControlFile { get; set; }
 
-        [JsonProperty("retry-wait")]
+        [JsonPropertyName("retry-wait")]
         public string RetryWait { get; set; }
 
-        [JsonProperty("reuse-uri")]
+        [JsonPropertyName("reuse-uri")]
         public string ReuseUri { get; set; }
 
-        [JsonProperty("rpc-save-upload-metadata")]
+        [JsonPropertyName("rpc-save-upload-metadata")]
         public string RpcSaveUploadMetadata { get; set; }
 
-        [JsonProperty("seed-ratio")]
+        [JsonPropertyName("seed-ratio")]
         public string SeedRatio { get; set; }
 
-        [JsonProperty("seed-time")]
+        [JsonPropertyName("seed-time")]
         public string SeedTime { get; set; }
 
-        [JsonProperty("select-file")]
+        [JsonPropertyName("select-file")]
         public string SelectFile { get; set; }
 
-        [JsonProperty("split")]
+        [JsonPropertyName("split")]
         public string Split { get; set; }
 
-        [JsonProperty("ssh-host-key-md")]
+        [JsonPropertyName("ssh-host-key-md")]
         public string SshHostKeyMd { get; set; }
 
-        [JsonProperty("stream-piece-selector")]
+        [JsonPropertyName("stream-piece-selector")]
         public string StreamPieceSelector { get; set; }
 
-        [JsonProperty("timeout")]
+        [JsonPropertyName("timeout")]
         public string Timeout { get; set; }
 
-        [JsonProperty("uri-selector")]
+        [JsonPropertyName("uri-selector")]
         public string UriSelector { get; set; }
 
-        [JsonProperty("use-head")]
+        [JsonPropertyName("use-head")]
         public string UseHead { get; set; }
 
-        [JsonProperty("user-agent")]
+        [JsonPropertyName("user-agent")]
         public string UserAgent { get; set; }
     }
 }

--- a/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaServer.cs
+++ b/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaServer.cs
@@ -4,29 +4,29 @@
  */
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 
 namespace AriaNet.Attributes
 {
     public class ServerDetail
     {
-        [JsonProperty("currentUri")]
+        [JsonPropertyName("currentUri")]
         public string CurrentUri { get; set; }
 
-        [JsonProperty("downloadSpeed")]
+        [JsonPropertyName("downloadSpeed")]
         public string DownloadSpeed { get; set; }
 
-        [JsonProperty("uri")]
+        [JsonPropertyName("uri")]
         public string Uri { get; set; }
     }
 
     public class AriaServer
     {
-        [JsonProperty("index")]
+        [JsonPropertyName("index")]
         public string Index { get; set; }
 
-        [JsonProperty("servers")]
+        [JsonPropertyName("servers")]
         public List<ServerDetail> Servers { get; set; }
     }
 }

--- a/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaSession.cs
+++ b/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaSession.cs
@@ -3,14 +3,13 @@
  * You can find the original code in this GitHub repository: https://github.com/huming2207/AriaNet
  */
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace AriaNet.Attributes
 {
-    [JsonObject]
     public class AriaSession
     {
-        [JsonProperty("sessionId")]
+        [JsonPropertyName("sessionId")]
         public string SessionId { get; set; }
     }
 }

--- a/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaStatus.cs
+++ b/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaStatus.cs
@@ -4,50 +4,50 @@
  */
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace AriaNet.Attributes
 {
     public class AriaStatus
     {
 
-        [JsonProperty("bitfield")]
+        [JsonPropertyName("bitfield")]
         public string Bitfield { get; set; }
 
-        [JsonProperty("completedLength")]
+        [JsonPropertyName("completedLength")]
         public string CompletedLength { get; set; }
 
-        [JsonProperty("connections")]
+        [JsonPropertyName("connections")]
         public string Connections { get; set; }
 
-        [JsonProperty("dir")]
+        [JsonPropertyName("dir")]
         public string Dir { get; set; }
 
-        [JsonProperty("downloadSpeed")]
+        [JsonPropertyName("downloadSpeed")]
         public string DownloadSpeed { get; set; }
 
-        [JsonProperty("files")]
+        [JsonPropertyName("files")]
         public List<AriaFile> Files { get; set; }
 
-        [JsonProperty("gid")]
+        [JsonPropertyName("gid")]
         public string TaskId { get; set; }
 
-        [JsonProperty("numPieces")]
+        [JsonPropertyName("numPieces")]
         public string NumPieces { get; set; }
 
-        [JsonProperty("pieceLength")]
+        [JsonPropertyName("pieceLength")]
         public string PieceLength { get; set; }
 
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; set; }
 
-        [JsonProperty("totalLength")]
+        [JsonPropertyName("totalLength")]
         public string TotalLength { get; set; }
 
-        [JsonProperty("uploadLength")]
+        [JsonPropertyName("uploadLength")]
         public string UploadLength { get; set; }
 
-        [JsonProperty("uploadSpeed")]
+        [JsonPropertyName("uploadSpeed")]
         public string UploadSpeed { get; set; }
     }
 }

--- a/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaTorrent.cs
+++ b/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaTorrent.cs
@@ -3,37 +3,37 @@
  * You can find the original code in this GitHub repository: https://github.com/huming2207/AriaNet
  */
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace AriaNet.Attributes
 {
     public class AriaTorrent
     {
-        [JsonProperty("amChoking")]
+        [JsonPropertyName("amChoking")]
         public string AmChoking { get; set; }
 
-        [JsonProperty("bitfield")]
+        [JsonPropertyName("bitfield")]
         public string BitField { get; set; }
 
-        [JsonProperty("downloadSpeed")]
+        [JsonPropertyName("downloadSpeed")]
         public string DownloadSpeed { get; set; }
 
-        [JsonProperty("ip")]
+        [JsonPropertyName("ip")]
         public string Ip { get; set; }
 
-        [JsonProperty("peerChoking")]
+        [JsonPropertyName("peerChoking")]
         public string PeerChoking { get; set; }
 
-        [JsonProperty("peerId")]
+        [JsonPropertyName("peerId")]
         public string PeerId { get; set; }
 
-        [JsonProperty("port")]
+        [JsonPropertyName("port")]
         public string Port { get; set; }
 
-        [JsonProperty("seeder")]
+        [JsonPropertyName("seeder")]
         public string Seeder { get; set; }
 
-        [JsonProperty("uploadSpeed")]
+        [JsonPropertyName("uploadSpeed")]
         public string UploadSpeed { get; set; }
     }
 }

--- a/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaUri.cs
+++ b/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaUri.cs
@@ -3,16 +3,16 @@
  * You can find the original code in this GitHub repository: https://github.com/huming2207/AriaNet
  */
 
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace AriaNet.Attributes
 {
     public class AriaUri
     {
-        [JsonProperty("status")]
+        [JsonPropertyName("status")]
         public string Status { get; set; }
 
-        [JsonProperty("uri")]
+        [JsonPropertyName("uri")]
         public string Uri { get; set; }
     }
 }

--- a/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaVersionInfo.cs
+++ b/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/Attributes/AriaVersionInfo.cs
@@ -4,17 +4,16 @@
  */
 
 using System.Collections.Generic;
-using Newtonsoft.Json;
+using System.Text.Json.Serialization;
 
 namespace AriaNet.Attributes
 {
-    [JsonObject]
     public class AriaVersionInfo
     {
-        [JsonProperty("enabledFeatures")]
+        [JsonPropertyName("enabledFeatures")]
         public List<string> EnabledFeatures { get; set; }
-        
-        [JsonProperty("version")]
+
+        [JsonPropertyName("version")]
         public string Version { get; set; }
     }
 }

--- a/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/JsonRpc/JsonRpcHttpClient.cs
+++ b/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/JsonRpc/JsonRpcHttpClient.cs
@@ -2,7 +2,7 @@
 using System.Net.Http;
 using System.Text;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Serilog;
 
 namespace XIVLauncher.Common.Game.Patch.Acquisition.Aria.JsonRpc
@@ -31,13 +31,13 @@ namespace XIVLauncher.Common.Game.Patch.Acquisition.Aria.JsonRpc
 
         public async Task<T> Invoke<T>(string method, params object[] args)
         {
-            var argsJson = JsonConvert.SerializeObject(args);
+            var argsJson = JsonSerializer.Serialize(args);
             Log.Debug($"[JSONRPC] method({method}) arg({argsJson})");
 
             var httpResponse = await _client.GetAsync(_endpoint + $"?method={method}&id={Guid.NewGuid()}&params={Base64Encode(argsJson)}");
             httpResponse.EnsureSuccessStatusCode();
 
-            var rpcResponse = JsonConvert.DeserializeObject<JsonRpcResponse<T>>(await httpResponse.Content.ReadAsStringAsync());
+            var rpcResponse = JsonSerializer.Deserialize<JsonRpcResponse<T>>(await httpResponse.Content.ReadAsStringAsync());
             return rpcResponse.Result;
         }
     }

--- a/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/JsonRpc/JsonRpcResponse.cs
+++ b/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/JsonRpc/JsonRpcResponse.cs
@@ -1,16 +1,16 @@
-﻿using Newtonsoft.Json;
+﻿using System.Text.Json.Serialization;
 
 namespace XIVLauncher.Common.Game.Patch.Acquisition.Aria.JsonRpc
 {
     public class JsonRpcResponse<T>
     {
-        [JsonProperty("id")]
+        [JsonPropertyName("id")]
         public string Id { get; set; }
 
-        [JsonProperty("jsonrpc")]
+        [JsonPropertyName("jsonrpc")]
         public string Version { get; set; }
 
-        [JsonProperty("result")]
+        [JsonPropertyName("result")]
         public T Result { get; set; }
     }
 }

--- a/src/XIVLauncher.Common/Game/Patch/PatchInstaller.cs
+++ b/src/XIVLauncher.Common/Game/Patch/PatchInstaller.cs
@@ -139,7 +139,7 @@ namespace XIVLauncher.Common.Game.Patch
             this.rpc.SendMessage(new PatcherIpcEnvelope
             {
                 OpCode = PatcherIpcOpCode.StartInstall,
-                Data = new PatcherIpcStartInstall
+                StartInstallInfo = new PatcherIpcStartInstall
                 {
                     GameDirectory = gameDirectory,
                     PatchFile = file,
@@ -155,7 +155,7 @@ namespace XIVLauncher.Common.Game.Patch
             this.rpc.SendMessage(new PatcherIpcEnvelope
             {
                 OpCode = PatcherIpcOpCode.Finish,
-                Data = gameDirectory
+                GameDirectory = gameDirectory
             });
         }
 

--- a/src/XIVLauncher.Common/Game/Patch/PatchVerifier.cs
+++ b/src/XIVLauncher.Common/Game/Patch/PatchVerifier.cs
@@ -10,7 +10,8 @@ using System.Net.Http;
 using System.Text.RegularExpressions;
 using System.Threading;
 using System.Threading.Tasks;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Serilog;
 using XIVLauncher.Common.Game.Exceptions;
 using XIVLauncher.Common.Patching.IndexedZiPatch;
@@ -92,40 +93,40 @@ namespace XIVLauncher.Common.Game.Patch
 
         private class VerifyVersions
         {
-            [JsonProperty("boot")]
+            [JsonPropertyName("boot")]
             public string Boot { get; set; }
 
-            [JsonProperty("bootRevision")]
+            [JsonPropertyName("bootRevision")]
             public int BootRevision { get; set; }
 
-            [JsonProperty("game")]
+            [JsonPropertyName("game")]
             public string Game { get; set; }
 
-            [JsonProperty("gameRevision")]
+            [JsonPropertyName("gameRevision")]
             public int GameRevision { get; set; }
 
-            [JsonProperty("ex1")]
+            [JsonPropertyName("ex1")]
             public string Ex1 { get; set; }
 
-            [JsonProperty("ex1Revision")]
+            [JsonPropertyName("ex1Revision")]
             public int Ex1Revision { get; set; }
 
-            [JsonProperty("ex2")]
+            [JsonPropertyName("ex2")]
             public string Ex2 { get; set; }
 
-            [JsonProperty("ex2Revision")]
+            [JsonPropertyName("ex2Revision")]
             public int Ex2Revision { get; set; }
 
-            [JsonProperty("ex3")]
+            [JsonPropertyName("ex3")]
             public string Ex3 { get; set; }
 
-            [JsonProperty("ex3Revision")]
+            [JsonPropertyName("ex3Revision")]
             public int Ex3Revision { get; set; }
 
-            [JsonProperty("ex4")]
+            [JsonPropertyName("ex4")]
             public string Ex4 { get; set; }
 
-            [JsonProperty("ex4Revision")]
+            [JsonPropertyName("ex4Revision")]
             public int Ex4Revision { get; set; }
         }
 
@@ -498,7 +499,7 @@ namespace XIVLauncher.Common.Game.Patch
             var latestVersionJson = await _client.GetStringAsync(BASE_URL + "latest.json").ConfigureAwait(false);
             _cancellationTokenSource.Token.ThrowIfCancellationRequested();
 
-            var latestVersion = JsonConvert.DeserializeObject<VerifyVersions>(latestVersionJson);
+            var latestVersion = JsonSerializer.Deserialize<VerifyVersions>(latestVersionJson);
 
             PatchSetIndex++;
             await this.GetRepoMeta(Repository.Ffxiv, latestVersion.Game, metaFolder, latestVersion.GameRevision).ConfigureAwait(false);

--- a/src/XIVLauncher.Common/Patching/RemotePatchInstaller.cs
+++ b/src/XIVLauncher.Common/Patching/RemotePatchInstaller.cs
@@ -35,7 +35,7 @@ public class RemotePatchInstaller
         rpc.SendMessage(new PatcherIpcEnvelope
         {
             OpCode = PatcherIpcOpCode.Hello,
-            Data = DateTime.Now
+            Timestamp = DateTime.Now
         });
 
         Log.Information("[PATCHER] sent hello");
@@ -87,12 +87,12 @@ public class RemotePatchInstaller
 
             case PatcherIpcOpCode.StartInstall:
 
-                var installData = (PatcherIpcStartInstall)envelope.Data;
+                var installData = envelope.StartInstallInfo;
                 this.queuedInstalls.Enqueue(installData);
                 break;
 
             case PatcherIpcOpCode.Finish:
-                var path = (DirectoryInfo)envelope.Data;
+                var path = envelope.GameDirectory;
 
                 try
                 {

--- a/src/XIVLauncher.Common/Patching/Rpc/Implementations/SharedMemoryRpc.cs
+++ b/src/XIVLauncher.Common/Patching/Rpc/Implementations/SharedMemoryRpc.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Text;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Serilog;
 using SharedMemory;
 using XIVLauncher.Common.PatcherIpc;
@@ -21,13 +22,13 @@ public class SharedMemoryRpc : IRpc, IDisposable
         var json = IpcHelpers.Base64Decode(Encoding.ASCII.GetString(payload));
         Log.Information("[SHMEMRPC] IPC({0}): {1}", msgId, json);
 
-        var msg = JsonConvert.DeserializeObject<PatcherIpcEnvelope>(json, IpcHelpers.JsonSettings);
+        var msg = JsonSerializer.Deserialize<PatcherIpcEnvelope>(json);
         MessageReceived?.Invoke(msg);
     }
 
     public void SendMessage(PatcherIpcEnvelope envelope)
     {
-        var json = IpcHelpers.Base64Encode(JsonConvert.SerializeObject(envelope, IpcHelpers.JsonSettings));
+        var json = IpcHelpers.Base64Encode(JsonSerializer.Serialize(envelope));
         this.rpcBuffer.RemoteRequest(Encoding.ASCII.GetBytes(json));
     }
 

--- a/src/XIVLauncher.Common/Patching/Rpc/IpcHelpers.cs
+++ b/src/XIVLauncher.Common/Patching/Rpc/IpcHelpers.cs
@@ -1,5 +1,3 @@
-using Newtonsoft.Json;
-
 namespace XIVLauncher.Common.PatcherIpc;
 
 public static class IpcHelpers
@@ -15,10 +13,4 @@ public static class IpcHelpers
         var base64EncodedBytes = System.Convert.FromBase64String(base64EncodedData);
         return System.Text.Encoding.UTF8.GetString(base64EncodedBytes);
     }
-
-    public static JsonSerializerSettings JsonSettings = new()
-    {
-        TypeNameAssemblyFormatHandling = TypeNameAssemblyFormatHandling.Full,
-        TypeNameHandling = TypeNameHandling.All
-    };
 }

--- a/src/XIVLauncher.Common/Patching/Rpc/PatcherIpcEnvelope.cs
+++ b/src/XIVLauncher.Common/Patching/Rpc/PatcherIpcEnvelope.cs
@@ -1,8 +1,22 @@
-﻿namespace XIVLauncher.Common.PatcherIpc
+﻿#nullable enable
+using System;
+using System.IO;
+using System.Text.Json.Serialization;
+
+namespace XIVLauncher.Common.PatcherIpc
 {
     public class PatcherIpcEnvelope
     {
         public PatcherIpcOpCode OpCode { get; set; }
-        public object Data { get; set; }
+        public DateTime? Timestamp { get; set; }
+        public PatcherIpcStartInstall? StartInstallInfo { get; set; }
+        public string? GameDirectoryPath { get; set; }
+
+        [JsonIgnore]
+        public DirectoryInfo? GameDirectory
+        {
+            get => new(GameDirectoryPath!);
+            set => GameDirectoryPath = value?.FullName;
+        }
     }
 }

--- a/src/XIVLauncher.Common/Patching/Rpc/PatcherIpcStartInstall.cs
+++ b/src/XIVLauncher.Common/Patching/Rpc/PatcherIpcStartInstall.cs
@@ -1,13 +1,29 @@
-﻿using System.IO;
+﻿#nullable enable
+using System.IO;
+using System.Text.Json.Serialization;
 
 namespace XIVLauncher.Common.PatcherIpc
 {
     public class PatcherIpcStartInstall
     {
-        public FileInfo PatchFile { get; set; }
         public Repository Repo { get; set; }
-        public string VersionId { get; set; }
-        public DirectoryInfo GameDirectory { get; set; }
+        public string VersionId { get; set; } = null!;
         public bool KeepPatch { get; set; }
+        public string? PatchFilePath { get; set; }
+        public string? GameDirectoryPath { get; set; }
+
+        [JsonIgnore]
+        public FileInfo? PatchFile
+        {
+            get => new(PatchFilePath!);
+            set => PatchFilePath = value?.FullName;
+        }
+
+        [JsonIgnore]
+        public DirectoryInfo? GameDirectory
+        {
+            get => new(GameDirectoryPath!);
+            set => GameDirectoryPath = value?.FullName;
+        }
     }
 }

--- a/src/XIVLauncher.Common/XIVLauncher.Common.csproj
+++ b/src/XIVLauncher.Common/XIVLauncher.Common.csproj
@@ -44,7 +44,6 @@
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="Downloader" Version="2.2.8" />
         <PackageReference Include="MonoTorrent" Version="2.0.0" />
-        <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
         <PackageReference Include="Serilog" Version="2.12.0" />
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
         <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/XIVLauncher.Common/XIVLauncher.Common.csproj
+++ b/src/XIVLauncher.Common/XIVLauncher.Common.csproj
@@ -50,8 +50,8 @@
         <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.1" />
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
         <PackageReference Include="SharedMemory" Version="2.3.2" />
-        <PackageReference Include="System.Memory" Version="4.5.4" />
+        <PackageReference Include="System.Memory" Version="4.5.5" />
         <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
-        <PackageReference Include="System.Text.Json" Version="6.0.6" />
+        <PackageReference Include="System.Text.Json" Version="7.0.0" />
     </ItemGroup>
 </Project>

--- a/src/XIVLauncher.PatchInstaller/XIVLauncher.PatchInstaller.csproj
+++ b/src/XIVLauncher.PatchInstaller/XIVLauncher.PatchInstaller.csproj
@@ -28,7 +28,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/XIVLauncher/Accounts/AccountManager.cs
+++ b/src/XIVLauncher/Accounts/AccountManager.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.ObjectModel;
 using System.IO;
 using System.Linq;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Serilog;
 using XIVLauncher.Common;
 using XIVLauncher.Settings;
@@ -82,7 +82,7 @@ namespace XIVLauncher.Accounts
 
         public void Save()
         {
-            File.WriteAllText(ConfigPath,  JsonConvert.SerializeObject(Accounts, Formatting.Indented));
+            File.WriteAllText(ConfigPath,  JsonSerializer.Serialize(Accounts, new JsonSerializerOptions { WriteIndented = true }));
         }
 
         public void Load()
@@ -94,7 +94,7 @@ namespace XIVLauncher.Accounts
                 Save();
             }
 
-            Accounts = JsonConvert.DeserializeObject<ObservableCollection<XivAccount>>(File.ReadAllText(ConfigPath));
+            Accounts = JsonSerializer.Deserialize<ObservableCollection<XivAccount>>(File.ReadAllText(ConfigPath));
 
             // If the file is corrupted, this will be null anyway
             Accounts ??= new ObservableCollection<XivAccount>();

--- a/src/XIVLauncher/Accounts/XivAccount.cs
+++ b/src/XIVLauncher/Accounts/XivAccount.cs
@@ -1,11 +1,11 @@
 ﻿using AdysTech.CredentialManager;
-using Newtonsoft.Json;
+using System.Text.Json.Nodes;
+using System.Text.Json.Serialization;
 using Serilog;
 using System;
 using System.ComponentModel;
 using System.Net;
 using System.Threading.Tasks;
-using Newtonsoft.Json.Linq;
 
 namespace XIVLauncher.Accounts
 {
@@ -136,7 +136,7 @@ namespace XIVLauncher.Accounts
 
         private const string URL = "https://xivapi.com/";
 
-        public static async Task<JObject> GetCharacterSearch(string name, string world)
+        public static async Task<JsonObject> GetCharacterSearch(string name, string world)
         {
             return await Get("character/search" + $"?name={name}&server={world}");
         }
@@ -148,7 +148,7 @@ namespace XIVLauncher.Accounts
             {
                 var result = client.DownloadString(URL + endpoint);
 
-                var parsedObject = JObject.Parse(result);
+                var parsedObject = JsonObject.Parse(result);
 
                 return parsedObject;
             }

--- a/src/XIVLauncher/App.xaml.cs
+++ b/src/XIVLauncher/App.xaml.cs
@@ -10,13 +10,12 @@ using System.Windows.Media;
 using CheapLoc;
 using CommandLine;
 using Config.Net;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Serilog;
 using Serilog.Events;
 using XIVLauncher.Common;
 using XIVLauncher.Common.Dalamud;
 using XIVLauncher.Common.Game;
-using XIVLauncher.Common.PlatformAbstractions;
 using XIVLauncher.Common.Support;
 using XIVLauncher.Common.Util;
 using XIVLauncher.Common.Windows;
@@ -232,7 +231,7 @@ namespace XIVLauncher
             var result = IntegrityCheck.RunIntegrityCheckAsync(new DirectoryInfo(path), null).GetAwaiter().GetResult();
             string saveIntegrityPath = Path.Combine(Paths.RoamingPath, $"{result.GameVersion}.json");
 
-            File.WriteAllText(saveIntegrityPath, JsonConvert.SerializeObject(result));
+            File.WriteAllText(saveIntegrityPath, JsonSerializer.Serialize(result));
 
             MessageBox.Show($"Successfully hashed {result.Hashes.Count} files to {path}.", "Hello Franz", MessageBoxButton.OK, MessageBoxImage.Asterisk);
             Environment.Exit(0);

--- a/src/XIVLauncher/Resources/LICENSE.txt
+++ b/src/XIVLauncher/Resources/LICENSE.txt
@@ -678,8 +678,7 @@ Public License instead of this License.  But first, please read
 For third-party dependencies, please refer to the package's respective license.
 
 Id                                        LicenseUrl                                                                             
---                                        ----------                                                                             
-Newtonsoft.Json                           https://licenses.nuget.org/MIT                                                         
+--                                        ----------                                                                                                                              
 Serilog                                   https://licenses.nuget.org/Apache-2.0                                                                                                                                 
 Serilog.Sinks.Console                     https://www.apache.org/licenses/LICENSE-2.0                                            
 Serilog.Sinks.Debug                       https://www.apache.org/licenses/LICENSE-2.0                                            

--- a/src/XIVLauncher/Settings/Parsers/AddonListParser.cs
+++ b/src/XIVLauncher/Settings/Parsers/AddonListParser.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using Config.Net;
-using Newtonsoft.Json;
+using System.Text.Json;
 using XIVLauncher.Common.Addon;
 
 namespace XIVLauncher.Settings.Parsers
@@ -13,7 +13,7 @@ namespace XIVLauncher.Settings.Parsers
         public string ToRawString(object value)
         {
             if (value is List<AddonEntry> list)
-                return JsonConvert.SerializeObject(list);
+                return JsonSerializer.Serialize(list);
 
             return null;
         }
@@ -28,7 +28,7 @@ namespace XIVLauncher.Settings.Parsers
 
             if (t == typeof(List<AddonEntry>))
             {
-                result = JsonConvert.DeserializeObject<List<AddonEntry>>(value);
+                result = JsonSerializer.Deserialize<List<AddonEntry>>(value);
                 return true;
             }
 

--- a/src/XIVLauncher/Settings/Parsers/CommonJsonParser.cs
+++ b/src/XIVLauncher/Settings/Parsers/CommonJsonParser.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Text.Json;
 using Config.Net;
-using Newtonsoft.Json;
 
 namespace XIVLauncher.Settings.Parsers;
 
@@ -11,7 +11,7 @@ public class CommonJsonParser<T> : ITypeParser
     {
         try
         {
-            result = JsonConvert.DeserializeObject(value, t);
+            result = JsonSerializer.Deserialize(value, t);
         }
         catch
         {
@@ -24,7 +24,7 @@ public class CommonJsonParser<T> : ITypeParser
 
     public string ToRawString(object value)
     {
-        return value == null ? null : JsonConvert.SerializeObject(value);
+        return value == null ? null : JsonSerializer.Serialize(value);
     }
 
     public IEnumerable<Type> SupportedTypes => new[] { typeof(T) };

--- a/src/XIVLauncher/Support/Troubleshooting.cs
+++ b/src/XIVLauncher/Support/Troubleshooting.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Linq;
 using System.Text;
-using Newtonsoft.Json;
+using System.Text.Json;
 using Serilog;
 using XIVLauncher.Common;
 using XIVLauncher.Common.Dalamud;
@@ -40,7 +40,7 @@ namespace XIVLauncher.Support
                     Info = exception.ToString(),
                 };
 
-                var encodedPayload = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonConvert.SerializeObject(payload)));
+                var encodedPayload = Convert.ToBase64String(Encoding.UTF8.GetBytes(JsonSerializer.Serialize(payload)));
                 Log.Information($"LASTEXCEPTION:{encodedPayload}");
             }
             catch (Exception)
@@ -118,7 +118,7 @@ namespace XIVLauncher.Support
                 IndexIntegrity = integrity
             };
 
-            return JsonConvert.SerializeObject(payload);
+            return JsonSerializer.Serialize(payload);
         }
 
         /// <summary>

--- a/src/XIVLauncher/Updates.cs
+++ b/src/XIVLauncher/Updates.cs
@@ -6,11 +6,11 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.Json;
 using System.Text.Json.Serialization;
 using System.Threading.Tasks;
 using System.Windows;
 using CheapLoc;
-using Newtonsoft.Json;
 using Serilog;
 using Squirrel;
 using XIVLauncher.Accounts;
@@ -65,16 +65,22 @@ namespace XIVLauncher
 #pragma warning disable CS8618
         public class Lease
         {
+            [JsonPropertyName("success")]
             public bool Success { get; set; }
 
+            [JsonPropertyName("message")]
             public string? Message { get; set; }
 
+            [JsonPropertyName("frontierUrl")]
             public string FrontierUrl { get; set; }
 
+            [JsonPropertyName("flags")]
             public LeaseFeatureFlags Flags { get; set; }
 
+            [JsonPropertyName("releasesList")]
             public string ReleasesList { get; set; }
 
+            [JsonPropertyName("validUntil")]
             public DateTime? ValidUntil { get; set; }
         }
 #pragma warning restore CS8618
@@ -165,10 +171,10 @@ namespace XIVLauncher
                 Log.Information("Updates: Received canary track lease!");
             }
 
-            var leaseData = JsonConvert.DeserializeObject<Lease>(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
+            var leaseData = JsonSerializer.Deserialize<Lease>(await response.Content.ReadAsStringAsync().ConfigureAwait(false));
 
-            if (!leaseData.Success)
-                throw new LeaseAcquisitionException(leaseData.Message!);
+            if (!leaseData?.Success ?? true)
+                throw new LeaseAcquisitionException(leaseData?.Message!);
 
             var fakeDownloader = new FakeSquirrelFileDownloader(leaseData, prerelease);
             var manager = new UpdateManager(FAKE_URL_PREFIX, "XIVLauncher", null, fakeDownloader);
@@ -190,7 +196,7 @@ namespace XIVLauncher
                 };
 
                 var text = await client.GetStringAsync(NEWS_URL).ConfigureAwait(false);
-                newsData = JsonConvert.DeserializeObject<ErrorNewsData>(text);
+                newsData = JsonSerializer.Deserialize<ErrorNewsData>(text);
             }
             catch (Exception newsEx)
             {

--- a/src/XIVLauncher/Windows/ChangelogWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/ChangelogWindow.xaml.cs
@@ -5,7 +5,8 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Windows;
 using Microsoft.Win32;
-using Newtonsoft.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
 using Serilog;
 using XIVLauncher.Common;
 using XIVLauncher.Support;
@@ -24,25 +25,25 @@ namespace XIVLauncher.Windows
 
         public class VersionMeta
         {
-            [JsonProperty("version")]
+            [JsonPropertyName("version")]
             public string Version { get; set; }
 
-            [JsonProperty("url")]
+            [JsonPropertyName("url")]
             public string Url { get; set; }
 
-            [JsonProperty("changelog")]
+            [JsonPropertyName("changelog")]
             public string Changelog { get; set; }
 
-            [JsonProperty("when")]
+            [JsonPropertyName("when")]
             public DateTime When { get; set; }
         }
 
         public class ReleaseMeta
         {
-            [JsonProperty("releaseVersion")]
+            [JsonPropertyName("releaseVersion")]
             public VersionMeta ReleaseVersion { get; set; }
 
-            [JsonProperty("prereleaseVersion")]
+            [JsonPropertyName("prereleaseVersion")]
             public VersionMeta PrereleaseVersion { get; set; }
         }
 
@@ -98,7 +99,7 @@ namespace XIVLauncher.Windows
                 try
                 {
                     using var client = new HttpClient();
-                    var response = JsonConvert.DeserializeObject<ReleaseMeta>(await client.GetStringAsync(META_URL));
+                    var response = JsonSerializer.Deserialize<ReleaseMeta>(await client.GetStringAsync(META_URL));
 
                     Dispatcher.Invoke(() => this.ChangeLogText.Text = _prerelease ? response.PrereleaseVersion.Changelog : response.ReleaseVersion.Changelog);
                 }

--- a/src/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
+using System.Text.Json.Nodes;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
@@ -11,7 +12,6 @@ using CheapLoc;
 using MaterialDesignThemes.Wpf.Transitions;
 using Serilog;
 using XIVLauncher.Common.Game;
-using Newtonsoft.Json.Linq;
 using XIVLauncher.Common;
 using XIVLauncher.Common.Addon;
 using XIVLauncher.Common.Addon.Implementations;
@@ -346,11 +346,11 @@ namespace XIVLauncher.Windows
 
             foreach (var path in definitionFiles)
             {
-                dynamic definition = JObject.Parse(File.ReadAllText(path));
+                var definition = (JsonObject)JsonNode.Parse(File.ReadAllText(path));
 
                 try
                 {
-                    if (PluginListView.SelectedValue.ToString().Contains(definition.Name.Value + " " + definition.AssemblyVersion.Value))
+                    if (PluginListView.SelectedValue.ToString().Contains($"{definition?["Name"]} {definition?["AssemblyVersion"]}"))
                     {
                         selectedPath = Path.GetDirectoryName(path);
                         break;
@@ -459,16 +459,16 @@ namespace XIVLauncher.Windows
                         continue;
                     }
 
-                    dynamic pluginConfig = JObject.Parse(File.ReadAllText(localInfoFile.FullName));
+                    var pluginConfig = JsonNode.Parse(File.ReadAllText(localInfoFile.FullName));
                     var isDisabled = File.Exists(Path.Combine(latest.FullName, ".disabled"));
 
                     if (isDisabled)
                     {
-                        PluginListView.Items.Add(pluginConfig.Name + " " + pluginConfig.AssemblyVersion + ViewModel.PluginDisabledTagLoc);
+                        PluginListView.Items.Add($"{pluginConfig!["Name"]} {pluginConfig!["AssemblyVersion"]}{ViewModel.PluginDisabledTagLoc}");
                     }
                     else
                     {
-                        PluginListView.Items.Add(pluginConfig.Name + " " + pluginConfig.AssemblyVersion);
+                        PluginListView.Items.Add($"{pluginConfig!["Name"]} {pluginConfig!["AssemblyVersion"]}");
                     }
                 }
             }

--- a/src/XIVLauncher/XIVLauncher.csproj
+++ b/src/XIVLauncher/XIVLauncher.csproj
@@ -87,7 +87,7 @@
     <PackageReference Include="SharedMemory" Version="2.3.2" />
     <PackageReference Include="squirrel.windows" Version="1.9.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
-    <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
+    <PackageReference Include="System.Text.Encodings.Web" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Completely removes and replaces Newtonsoft.Json 

Everything should be functionally equivalent, except for `Headlines` deserialization, which works, but is not a 1:1 translation of the old options.

The remote patcher RPC has been slightly reworked to allow for deserialization without type information as well.