### PR TITLE
Unify Dalamud injector arguments

### DIFF
--- a/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
@@ -45,30 +45,30 @@ public class UnixDalamudRunner : IDalamudRunner
         var launchArguments = new List<string>
         {
             $"\"{runner.FullName}\"",
-            "launch",
-            $"--mode={(loadMethod == DalamudLoadMethod.EntryPoint ? "entrypoint" : "inject")}",
-            $"--game=\"{gameExePath}\"",
-            $"--dalamud-working-directory=\"{startInfo.WorkingDirectory}\"",
-            $"--dalamud-configuration-path=\"{startInfo.ConfigurationPath}\"",
-            $"--dalamud-plugin-directory=\"{startInfo.PluginDirectory}\"",
-            $"--dalamud-dev-plugin-directory=\"{startInfo.DefaultPluginDirectory}\"",
-            $"--dalamud-asset-directory=\"{startInfo.AssetDirectory}\"",
-            $"--dalamud-client-language={(int)startInfo.Language}",
-            $"--dalamud-delay-initialize={startInfo.DelayInitializeMs}",
-            $"--dalamud-tspack-b64={Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(startInfo.TroubleshootingPackData))}",
+            DalamudInjectorArgs.Launch,
+            DalamudInjectorArgs.Mode(loadMethod == DalamudLoadMethod.EntryPoint ? "entrypoint" : "inject"),
+            DalamudInjectorArgs.Game(gameExePath),
+            DalamudInjectorArgs.WorkingDirectory(startInfo.WorkingDirectory),
+            DalamudInjectorArgs.ConfigurationPath(startInfo.ConfigurationPath),
+            DalamudInjectorArgs.PluginDirectory(startInfo.PluginDirectory),
+            DalamudInjectorArgs.PluginDevDirectory(startInfo.DefaultPluginDirectory),
+            DalamudInjectorArgs.AssetDirectory(startInfo.AssetDirectory),
+            DalamudInjectorArgs.ClientLanguage((int)startInfo.Language),
+            DalamudInjectorArgs.DelayInitialize(startInfo.DelayInitializeMs),
+            DalamudInjectorArgs.TSPackB64(Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(startInfo.TroubleshootingPackData))),
         };
 
         if (loadMethod == DalamudLoadMethod.ACLonly)
-            launchArguments.Add("--without-dalamud");
+            launchArguments.Add(DalamudInjectorArgs.WithoutDalamud);
 
         if (fakeLogin)
-            launchArguments.Add("--fake-arguments");
+            launchArguments.Add(DalamudInjectorArgs.FakeArguments);
 
         if (noPlugins)
-            launchArguments.Add("--no-plugins");
+            launchArguments.Add(DalamudInjectorArgs.NoPlugin);
 
         if (noThirdPlugins)
-            launchArguments.Add("--no-third-plugins");
+            launchArguments.Add(DalamudInjectorArgs.NoThirdParty);
 
         launchArguments.Add("--");
         launchArguments.Add(gameArgs);

--- a/src/XIVLauncher.Common.Windows/WindowsDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Windows/WindowsDalamudRunner.cs
@@ -18,31 +18,31 @@ public class WindowsDalamudRunner : IDalamudRunner
 
         var launchArguments = new List<string>
         {
-            "launch",
-            $"--mode={(loadMethod == DalamudLoadMethod.EntryPoint ? "entrypoint" : "inject")}",
-            $"--handle-owner={(long)inheritableCurrentProcess.Handle}",
-            $"--game=\"{gameExe.FullName}\"",
-            $"--dalamud-working-directory=\"{startInfo.WorkingDirectory}\"",
-            $"--dalamud-configuration-path=\"{startInfo.ConfigurationPath}\"",
-            $"--dalamud-plugin-directory=\"{startInfo.PluginDirectory}\"",
-            $"--dalamud-dev-plugin-directory=\"{startInfo.DefaultPluginDirectory}\"",
-            $"--dalamud-asset-directory=\"{startInfo.AssetDirectory}\"",
-            $"--dalamud-client-language={(int)startInfo.Language}",
-            $"--dalamud-delay-initialize={startInfo.DelayInitializeMs}",
-            $"--dalamud-tspack-b64={Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(startInfo.TroubleshootingPackData))}",
+            DalamudInjectorArgs.Launch,
+            DalamudInjectorArgs.Mode(loadMethod == DalamudLoadMethod.EntryPoint ? "entrypoint" : "inject"),
+            DalamudInjectorArgs.HandleOwner((long)inheritableCurrentProcess.Handle),
+            DalamudInjectorArgs.Game(gameExe.FullName),
+            DalamudInjectorArgs.WorkingDirectory(startInfo.WorkingDirectory),
+            DalamudInjectorArgs.ConfigurationPath(startInfo.ConfigurationPath),
+            DalamudInjectorArgs.PluginDirectory(startInfo.PluginDirectory),
+            DalamudInjectorArgs.PluginDevDirectory(startInfo.DefaultPluginDirectory),
+            DalamudInjectorArgs.AssetDirectory(startInfo.AssetDirectory),
+            DalamudInjectorArgs.ClientLanguage((int)startInfo.Language),
+            DalamudInjectorArgs.DelayInitialize(startInfo.DelayInitializeMs),
+            DalamudInjectorArgs.TSPackB64(Convert.ToBase64String(System.Text.Encoding.UTF8.GetBytes(startInfo.TroubleshootingPackData))),
         };
 
         if (loadMethod == DalamudLoadMethod.ACLonly)
-            launchArguments.Add("--without-dalamud");
+            launchArguments.Add(DalamudInjectorArgs.WithoutDalamud);
 
         if (fakeLogin)
-            launchArguments.Add("--fake-arguments");
+            launchArguments.Add(DalamudInjectorArgs.FakeArguments);
 
         if (noPlugins)
-            launchArguments.Add("--no-plugin");
+            launchArguments.Add(DalamudInjectorArgs.NoPlugin);
 
         if (noThirdPlugins)
-            launchArguments.Add("--no-3rd-plugin");
+            launchArguments.Add(DalamudInjectorArgs.NoThirdParty);
 
         launchArguments.Add("--");
         launchArguments.Add(gameArgs);

--- a/src/XIVLauncher.Common/Dalamud/DalamudInjectorArgs.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudInjectorArgs.cs
@@ -1,0 +1,22 @@
+namespace XIVLauncher.Common.Dalamud
+{
+    public static class DalamudInjectorArgs
+    {
+        public const string Launch = "launch";
+        public const string WithoutDalamud = "--without-dalamud";
+        public const string FakeArguments = "--fake-arguments";
+        public const string NoPlugin = "--no-plugin";
+        public const string NoThirdParty = "--no-3rd-plugin";
+        public static string Mode(string method) => $"--mode={method}";
+        public static string Game(string path) => $"--game=\"{path}\"";
+        public static string HandleOwner(long handle) => $"--handle-owner={handle}";
+        public static string WorkingDirectory(string path) => $"--dalamud-working-directory=\"{path}\"";
+        public static string ConfigurationPath(string path) => $"--dalamud-configuration-path=\"{path}\"";
+        public static string PluginDirectory(string path) => $"--dalamud-plugin-directory=\"{path}\"";
+        public static string PluginDevDirectory(string path) => $"--dalamud-dev-plugin-directory=\"{path}\"";
+        public static string AssetDirectory(string path) => $"--dalamud-asset-directory=\"{path}\"";
+        public static string ClientLanguage(int language) => $"--dalamud-client-language={language}";
+        public static string DelayInitialize(int delay) => $"--dalamud-delay-initialize={delay}";
+        public static string TSPackB64(string data) => $"--dalamud-tspack-b64={data}";
+    }
+}


### PR DESCRIPTION
This PR resolves the issues with the `UNIX` Dalamud injector arguments being very out of date by moving both the `Windows` and `UNIX` arguments into one class.

https://github.com/goatcorp/XIVLauncher.Core/pull/28 is blocked by this PR

CC: @NotNite