### PR TITLE
[xlcore][feature] Implement Run functions on the runners

### DIFF
--- a/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
@@ -31,4 +31,37 @@ public class UnixGameRunner : IGameRunner
             return compatibility.RunInPrefix($"\"{path}\" {arguments}", workingDirectory, environment, writeLog: true);
         }
     }
+
+    public Process? Run(string path, string workingDirectory, string arguments, IDictionary<string, string> environment, bool withCompatibility)
+    {
+        if (withCompatibility)
+        {
+            return compatibility.RunInPrefix($"\"{path}\" {arguments}", workingDirectory, environment, writeLog: true);
+        }
+        
+        var psi = new ProcessStartInfo(path, arguments)
+        {
+            WorkingDirectory = workingDirectory
+        };
+
+        foreach (var envVar in environment)
+        {
+            if (psi.Environment.ContainsKey(envVar.Key))
+            {
+                psi.Environment[envVar.Key] = envVar.Value;
+            }
+            else
+            {
+                psi.Environment.Add(envVar.Key, envVar.Value);
+            }
+        }
+
+        var p = new Process()
+        {
+            StartInfo = psi
+        };
+        p.Start();
+
+        return p;
+    }
 }

--- a/src/XIVLauncher.Common.Windows/WindowsGameRunner.cs
+++ b/src/XIVLauncher.Common.Windows/WindowsGameRunner.cs
@@ -44,4 +44,32 @@ public class WindowsGameRunner : IGameRunner
             return NativeAclFix.LaunchGame(workingDirectory, path, arguments, environment, dpiAwareness, process => { });
         }
     }
+    
+    public Process? Run(string path, string workingDirectory, string arguments, IDictionary<string, string> environment, bool withCompatibility)
+    {
+        var psi = new ProcessStartInfo(path, arguments)
+        {
+            WorkingDirectory = workingDirectory
+        };
+
+        foreach (var envVar in environment)
+        {
+            if (psi.Environment.ContainsKey(envVar.Key))
+            {
+                psi.Environment[envVar.Key] = envVar.Value;
+            }
+            else
+            {
+                psi.Environment.Add(envVar.Key, envVar.Value);
+            }
+        }
+
+        var p = new Process()
+        {
+            StartInfo = psi
+        };
+        p.Start();
+
+        return p;
+    }
 }

--- a/src/XIVLauncher.Common/PlatformAbstractions/IGameRunner.cs
+++ b/src/XIVLauncher.Common/PlatformAbstractions/IGameRunner.cs
@@ -6,4 +6,6 @@ namespace XIVLauncher.Common.PlatformAbstractions;
 public interface IGameRunner
 {
     Process? Start(string path, string workingDirectory, string arguments, IDictionary<string, string> environment, DpiAwareness dpiAwareness);
+    
+    Process? Run(string path, string workingDirectory, string arguments, IDictionary<string, string> environment, bool withCompatibility);
 }


### PR DESCRIPTION
This PR adds support for executing processes using the game runner. It works mostly the same as launching the game, but it accepts an arbitrary program instead. On Linux, the `withCompatibility` option runs the program in the Wine prefix instead, while on Windows, the flag does nothing.

If using the game runners is not suitable, it can also use its own runner instead.

This PR is a requirement for my autostart PR on XLCore and requires these changes to work.