### PR TITLE
[xlcore][feature] Add support for Proton as a runner

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -222,7 +222,7 @@ public class CompatibilityTools
             compatMounts = Proton.CompatMounts + (compatMounts.Equals("") ? "" : ":" + compatMounts);
             wineEnviromentVariables.Add("STEAM_COMPAT_MOUNTS", compatMounts);
 
-            wineEnviromentVariables.Add("PROTON_LOG", "1");
+            // User can add "PROTON_LOG=1" as env variable if they want logging. Will log to ~/.xlcore/logs/steam-<gameid>.log
             wineEnviromentVariables.Add("PROTON_LOG_DIR", Path.Combine(Proton.Prefix.Parent.FullName, "logs"));
             if (!Settings.FsyncOn) wineEnviromentVariables.Add("PROTON_NO_FSYNC", "1");
         }

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -354,7 +354,7 @@ public class CompatibilityTools
         psi.RedirectStandardOutput = true;
         psi.RedirectStandardError = true;
         psi.UseShellExecute = false;
-        psi.ArgumentList.Add("-f");
+        psi.ArgumentList.Add("-n");
         psi.ArgumentList.Add(executableName);
 
         Process pidget = new();

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -200,8 +200,7 @@ public class CompatibilityTools
             string compatMounts = Environment.GetEnvironmentVariable("STEAM_COMPAT_MOUNTS") ?? "";
             compatMounts = Proton.CompatMounts + (compatMounts.Equals("") ? "" : ":" + compatMounts);
             wineEnviromentVariables.Add("STEAM_COMPAT_MOUNTS", compatMounts);
-            
-            //wineEnviromentVariables.Add("PRESSURE_VESSEL_RUNTIME_BASE", Path.Combine(Proton.SteamRoot,"steamapps","common","SteamLinuxRuntime_soldier"));
+
             wineEnviromentVariables.Add("PROTON_LOG", "1");
             wineEnviromentVariables.Add("PROTON_LOG_DIR", Path.Combine(Proton.Prefix.Parent.FullName, "logs"));
             if (!Settings.FsyncOn) wineEnviromentVariables.Add("PROTON_NO_FSYNC", "1");

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -82,15 +82,19 @@ public class CompatibilityTools
 
     public async Task EnsureTool(DirectoryInfo tempPath)
     {
-        if (!File.Exists(Wine64Path))
+        if (!useProton)
         {
-            Log.Information("Compatibility tool does not exist, downloading");
-            await DownloadTool(tempPath).ConfigureAwait(false);
+            if (!File.Exists(Wine64Path))
+            {
+                Log.Information("Compatibility tool does not exist, downloading");
+                await DownloadTool(tempPath).ConfigureAwait(false);
+            }
+
+            EnsurePrefix();
+            await Dxvk.InstallDxvk(Settings.Prefix, dxvkDirectory).ConfigureAwait(false);
         }
-
-        EnsurePrefix();
-        await Dxvk.InstallDxvk(Settings.Prefix, dxvkDirectory).ConfigureAwait(false);
-
+        else
+            EnsurePrefix();
         IsToolReady = true;
     }
 

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -52,7 +52,7 @@ public class CompatibilityTools
     private readonly bool gamemodeOn;
     private readonly string dxvkAsyncOn;
 
-    private bool useProton => string.IsNullOrEmpty(Environment.GetEnvironmentVariable("XLC_PROTON")) ? false :
+    public bool useProton => string.IsNullOrEmpty(Environment.GetEnvironmentVariable("XLC_PROTON")) ? false :
             Environment.GetEnvironmentVariable("XLC_PROTON") == "1" || Environment.GetEnvironmentVariable("XLC_PROTON").ToLower() == "true";
 
     public CompatibilityTools(WineSettings wineSettings, Dxvk.DxvkHudType hudType, bool? gamemodeOn, bool? dxvkAsyncOn, DirectoryInfo toolsFolder)
@@ -339,6 +339,28 @@ public class CompatibilityTools
         var matchingLines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries).Skip(1).Where(
             l => int.Parse(l.Substring(1, 8), System.Globalization.NumberStyles.HexNumber) == winePid);
         var unixPids = matchingLines.Select(l => int.Parse(l.Substring(10, 8), System.Globalization.NumberStyles.HexNumber)).ToArray();
+        return unixPids.FirstOrDefault();
+    }
+
+    public Int32 GetUnixProcessIdByName(string executableName)
+    {
+        Console.WriteLine($"Process Name = {executableName}");
+        ProcessStartInfo psi = new ProcessStartInfo("pgrep");
+        psi.RedirectStandardOutput = true;
+        psi.RedirectStandardError = true;
+        psi.UseShellExecute = false;
+        psi.ArgumentList.Add("-f");
+        psi.ArgumentList.Add(executableName);
+
+        Process pidget = new();
+        pidget.StartInfo = psi;
+        pidget.Start();
+
+        var output = pidget.StandardOutput.ReadToEnd();
+        if (string.IsNullOrWhiteSpace(output))
+            return 0;
+        var matchingLines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+        var unixPids = matchingLines.Select(l => int.Parse(l, System.Globalization.NumberStyles.Integer)).ToArray();
         return unixPids.FirstOrDefault();
     }
 

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -125,43 +125,6 @@ public class CompatibilityTools
 
     public void EnsurePrefix()
     {
-        // if (UseProton && !File.Exists(Path.Combine(Proton.Prefix.FullName, "tracked_files")))
-        // {
-        //     // "proton run" must be run at least once to activate the proton prefix
-        //     ProcessStartInfo psi = new ProcessStartInfo(Proton.ProtonPath);
-        //     psi.RedirectStandardOutput = true;
-        //     psi.RedirectStandardError = true;
-        //     psi.UseShellExecute = false;
-        //     psi.Arguments = "run";
-        //     psi.EnvironmentVariables.Add("STEAM_COMPAT_DATA_PATH", Proton.Prefix.FullName);
-        //     psi.EnvironmentVariables.Add("STEAM_COMPAT_CLIENT_INSTALL_PATH", Proton.SteamRoot); 
-
-        //     Process firstrun = new();
-        //     firstrun.StartInfo = psi;
-
-        //     firstrun.ErrorDataReceived += new DataReceivedEventHandler((_, errLine) =>
-        //     {
-        //         if (String.IsNullOrEmpty(errLine.Data))
-        //             return;
-
-        //         try
-        //         {
-        //             logWriter.WriteLine(errLine.Data);
-        //             Console.Error.WriteLine(errLine.Data);
-        //         }
-        //         catch (Exception ex) when (ex is ArgumentOutOfRangeException ||
-        //                                 ex is OverflowException ||
-        //                                 ex is IndexOutOfRangeException)
-        //         {
-        //             // very long wine log lines get chopped off after a (seemingly) arbitrary limit resulting in strings that are not null terminated
-        //             //logWriter.WriteLine("Error writing Wine log line:");
-        //             //logWriter.WriteLine(ex.Message);
-        //         }
-        //     });
-
-        //     firstrun.Start();
-        // }
-
         RunInPrefix("cmd /c dir %userprofile%/Documents > nul", verb: "run").WaitForExit();
     }
 
@@ -179,7 +142,7 @@ public class CompatibilityTools
             psi.Arguments = command;
         }
 
-        Log.Information($"Running in prefix: {psi.FileName} {psi.Arguments}");
+        Log.Verbose($"Running in prefix: {psi.FileName} {psi.Arguments}");
         return RunInPrefix(psi, workingDirectory, environment, redirectOutput, writeLog, wineD3D);
     }
 
@@ -200,7 +163,7 @@ public class CompatibilityTools
         foreach (var arg in args)
             psi.ArgumentList.Add(arg);
 
-        Log.Information("Running in prefix (by array): {FileName} {Arguments}", psi.FileName, string.Join(' ', psi.ArgumentList)); //psi.ArgumentList.Aggregate(string.Empty, (a, b) => a + " " + b));
+        Log.Verbose("Running in prefix (by array): {FileName} {Arguments}", psi.FileName, string.Join(' ', psi.ArgumentList)); //psi.ArgumentList.Aggregate(string.Empty, (a, b) => a + " " + b));
         return RunInPrefix(psi, workingDirectory, environment, redirectOutput, writeLog, wineD3D);
     }
 

--- a/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/CompatibilityTools.cs
@@ -41,9 +41,9 @@ public class CompatibilityTools
     private string Wine64Path => Path.Combine(WineBinPath, "wine64");
     private string WineServerPath => Path.Combine(WineBinPath, "wineserver");
 
-    private string SteamRoot => Settings.SteamRoot;
+    private string SteamRoot => Settings.Proton.SteamRoot;
     private string SoldierRuntime => Path.Combine(SteamRoot,"steamapps","common","SteamLinuxRuntime_soldier");
-    private string ProtonPath => Path.Combine(Settings.ProtonPath,"proton");
+    private string ProtonPath => Path.Combine(Settings.Proton.ProtonPath,"proton");
 
     public bool IsToolDownloaded => File.Exists(Wine64Path) && Settings.Prefix.Exists;
 
@@ -205,7 +205,7 @@ public class CompatibilityTools
             wineEnviromentVariables.Add("DRI_PRIME","0");
             wineEnviromentVariables.Add("STEAM_COMPAT_DATA_PATH", Settings.ProtonPrefix.FullName);
             wineEnviromentVariables.Add("STEAM_COMPAT_CLIENT_INSTALL_PATH", SteamRoot);
-            wineEnviromentVariables.Add("STEAM_COMPAT_MOUNTS","/games/other/FFXIV");
+            wineEnviromentVariables.Add("STEAM_COMPAT_MOUNTS", Settings.Proton.CompatMounts);
             wineEnviromentVariables.Add("PRESSURE_VESSEL_RUNTIME_BASE", Path.Combine(SteamRoot,"steamapps","common","SteamLinuxRuntime_soldier"));
             wineEnviromentVariables.Add("PROTON_LOG", "1");
             wineEnviromentVariables.Add("PROTON_LOG_DIR", Path.Combine(Settings.ProtonPrefix.Parent.FullName, "logs"));
@@ -329,7 +329,6 @@ public class CompatibilityTools
         });
 
         helperProcess.Start();
-        Log.Information($"Name: {helperProcess.ProcessName} Handle: {helperProcess.Handle}, Pid: {helperProcess.Id}");
         if (writeLog)
             helperProcess.BeginErrorReadLine();
 
@@ -370,13 +369,10 @@ public class CompatibilityTools
         psi.ArgumentList.Add("-fn");
         psi.ArgumentList.Add(executableName);
 
-        Log.Information($"{psi.FileName} {string.Join(" ", psi.ArgumentList)}");
-
         Process pgrep = new();
         pgrep.StartInfo = psi;
         pgrep.Start();
         var output = pgrep.StandardOutput.ReadToEnd();
-        Log.Information(output);
         if (string.IsNullOrWhiteSpace(output))
             return 0;
         var matchingLines = output.Split('\n', StringSplitOptions.RemoveEmptyEntries);

--- a/src/XIVLauncher.Common.Unix/Compatibility/ProtonSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/ProtonSettings.cs
@@ -1,0 +1,32 @@
+using System;
+using System.IO;
+
+namespace XIVLauncher.Common.Unix.Compatibility;
+
+public struct ProtonSettings
+{
+    public string SteamRoot { get; }
+
+    public string ProtonPath { get; }
+
+    public string SteamLibrary => Path.Combine(SteamRoot, "steamapps", "common");
+
+    public string SoldierRun => Path.Combine(SteamLibrary, "SteamLinuxRuntime_soldier", "run");
+
+    public string SoldierInject => Path.Combine(SteamLibrary, "SteamLinuxRuntime_soldier","_v2-entry-point");
+
+    public string GamePath { get; }
+
+    public string ConfigPath { get; }
+
+    public string CompatMounts => GamePath + ':' + ConfigPath;
+
+    public ProtonSettings(string steamRoot, string protonPath, string gamePath = "", string configPath = "")
+    {
+        string xlcore = Path.Combine(Environment.GetEnvironmentVariable("HOME"), ".xlcore");
+        SteamRoot = steamRoot;
+        ProtonPath = protonPath;
+        GamePath = string.IsNullOrEmpty(gamePath) ? Path.Combine(xlcore, "ffxiv") : gamePath;
+        ConfigPath = string.IsNullOrEmpty(configPath) ? Path.Combine(xlcore, "ffxivConfig") : configPath;
+    }
+}

--- a/src/XIVLauncher.Common.Unix/Compatibility/ProtonSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/ProtonSettings.cs
@@ -76,15 +76,18 @@ public class ProtonSettings
         List<string> commands = new List<string>();
         if (UseReaper)
         {
-            commands.Add("SteamLaunch --");
+            commands.Add("SteamLaunch");
+            commands.Add("--");
         }
         if (UseSoldier)
         {
             if (UseReaper) commands.Add(inject ? SoldierInject : SoldierRun);
-            commands.Add(inject ? "--verb=waitforexitandrun --" : "--");
+            if (inject) commands.Add("--verb=waitforexitandrun");
+            commands.Add("--");
+
         }
         if (UseSoldier || UseReaper)
-            commands.Add("\"" + ProtonPath + "\"");
+            commands.Add(ProtonPath);
         commands.Add(verb);
 
         return commands.ToArray();

--- a/src/XIVLauncher.Common.Unix/Compatibility/ProtonSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/ProtonSettings.cs
@@ -40,13 +40,20 @@ public class ProtonSettings
         ProtonPath = Path.Combine(protonPath, "proton");
         GamePath = string.IsNullOrEmpty(gamePath) ? Path.Combine(xlcore, "ffxiv") : gamePath;
         ConfigPath = string.IsNullOrEmpty(configPath) ? Path.Combine(xlcore, "ffxivConfig") : configPath;
+#if FLATPAK
+        UseSoldier = false; // Already in a flatpak container, so this is ignored. Pressure-vessel and flatpak don't like to share.
+#else
         UseSoldier = useSoldier;
+#endif
         UseReaper = useReaper;
         SteamAppId = appId;
     }
 
     public string GetCommand(bool inject = true)
     {
+#if FLATPAK
+        inject = true;
+#endif
         if (UseReaper) return ReaperPath;
         if (UseSoldier) return inject ? SoldierInject : SoldierRun;
         return ProtonPath;   

--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -19,8 +19,6 @@ public class WineSettings
     public WineStartupType StartupType { get; private set; }
     public string CustomBinPath { get; private set; }
 
-    public ProtonSettings Proton { get; private set; }
-
     public bool EsyncOn { get; private set; }
     public bool FsyncOn { get; private set; }
 
@@ -29,22 +27,14 @@ public class WineSettings
 
     public DirectoryInfo Prefix { get; private set; }
 
-    public WineSettings(WineStartupType? startupType, string customBinPath, ProtonSettings protonSettings, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
+    public WineSettings(WineStartupType? startupType, string customBinPath, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
     {
         this.StartupType = startupType ?? WineStartupType.Custom;
         this.CustomBinPath = customBinPath;
-        this.Proton = protonSettings;
-        this.EsyncOn = esyncOn ?? false;
+         this.EsyncOn = esyncOn ?? false;
         this.FsyncOn = fsyncOn ?? false;
         this.DebugVars = debugVars;
         this.LogFile = logFile;
         this.Prefix = prefix;
     }
-
-    public WineSettings(WineStartupType? startupType, string customBinPath, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
-        : this(startupType, customBinPath, new ProtonSettings(new DirectoryInfo(Path.Combine(prefix.Parent.FullName,"protonprefix")),
-            Path.Combine(System.Environment.GetEnvironmentVariable("HOME"),".steam","root"),
-            Path.Combine(System.Environment.GetEnvironmentVariable("HOME"),".steam","root","steamapps","common","Proton 7.0")),
-            debugVars, logFile, prefix, esyncOn, fsyncOn)
-    {    }
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -7,6 +7,9 @@ public enum WineStartupType
     [SettingsDescription("Managed by XIVLauncher", "The game installation and wine setup is managed by XIVLauncher - you can leave it up to us.")]
     Managed,
 
+    [SettingsDescription("Proton (requires Steam)", "Use a Proton installation, which includes DXVK and other features. Experimental.")]
+    Proton,
+
     [SettingsDescription("Custom", "Point XIVLauncher to a custom location containing wine binaries to run the game with.")]
     Custom,
 }
@@ -16,22 +19,35 @@ public class WineSettings
     public WineStartupType StartupType { get; private set; }
     public string CustomBinPath { get; private set; }
 
-    public string EsyncOn { get; private set; }
-    public string FsyncOn { get; private set; }
+    public string SteamRoot { get; private set; }
+    public string ProtonPath { get; private set; }
+
+    public bool EsyncOn { get; private set; }
+    public bool FsyncOn { get; private set; }
 
     public string DebugVars { get; private set; }
     public FileInfo LogFile { get; private set; }
 
     public DirectoryInfo Prefix { get; private set; }
+    public DirectoryInfo ProtonPrefix { get; private set; }
 
-    public WineSettings(WineStartupType? startupType, string customBinPath, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
+    public WineSettings(WineStartupType? startupType, string customBinPath, string steamRoot, string protonPath, string debugVars, FileInfo logFile, DirectoryInfo prefix, DirectoryInfo protonPrefix, bool? esyncOn, bool? fsyncOn)
     {
         this.StartupType = startupType ?? WineStartupType.Custom;
         this.CustomBinPath = customBinPath;
-        this.EsyncOn = (esyncOn ?? false) ? "1" : "0";
-        this.FsyncOn = (fsyncOn ?? false) ? "1" : "0";
+        this.SteamRoot = steamRoot;
+        this.ProtonPath = protonPath;
+        this.EsyncOn = esyncOn ?? false;
+        this.FsyncOn = fsyncOn ?? false;
         this.DebugVars = debugVars;
         this.LogFile = logFile;
         this.Prefix = prefix;
+        this.ProtonPrefix = protonPrefix;
     }
+
+    public WineSettings(WineStartupType? startupType, string customBinPath, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
+        : this(startupType, customBinPath, Path.Combine(System.Environment.GetEnvironmentVariable("HOME"),".steam","root"),
+            Path.Combine(System.Environment.GetEnvironmentVariable("HOME"),".steam","root","steamapps","common","Proton 7.0"),
+            debugVars, logFile, prefix, new DirectoryInfo(Path.Combine(prefix.Parent.FullName,"protonprefix")), esyncOn, fsyncOn)
+    {    }
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -28,9 +28,8 @@ public class WineSettings
     public FileInfo LogFile { get; private set; }
 
     public DirectoryInfo Prefix { get; private set; }
-    public DirectoryInfo ProtonPrefix { get; private set; }
 
-    public WineSettings(WineStartupType? startupType, string customBinPath, ProtonSettings protonSettings, string debugVars, FileInfo logFile, DirectoryInfo prefix, DirectoryInfo protonPrefix, bool? esyncOn, bool? fsyncOn)
+    public WineSettings(WineStartupType? startupType, string customBinPath, ProtonSettings protonSettings, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
     {
         this.StartupType = startupType ?? WineStartupType.Custom;
         this.CustomBinPath = customBinPath;
@@ -40,12 +39,12 @@ public class WineSettings
         this.DebugVars = debugVars;
         this.LogFile = logFile;
         this.Prefix = prefix;
-        this.ProtonPrefix = protonPrefix;
     }
 
     public WineSettings(WineStartupType? startupType, string customBinPath, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
-        : this(startupType, customBinPath, new ProtonSettings(Path.Combine(System.Environment.GetEnvironmentVariable("HOME"),".steam","root"),
+        : this(startupType, customBinPath, new ProtonSettings(new DirectoryInfo(Path.Combine(prefix.Parent.FullName,"protonprefix")),
+            Path.Combine(System.Environment.GetEnvironmentVariable("HOME"),".steam","root"),
             Path.Combine(System.Environment.GetEnvironmentVariable("HOME"),".steam","root","steamapps","common","Proton 7.0")),
-            debugVars, logFile, prefix, new DirectoryInfo(Path.Combine(prefix.Parent.FullName,"protonprefix")), esyncOn, fsyncOn)
+            debugVars, logFile, prefix, esyncOn, fsyncOn)
     {    }
 }

--- a/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/WineSettings.cs
@@ -19,8 +19,7 @@ public class WineSettings
     public WineStartupType StartupType { get; private set; }
     public string CustomBinPath { get; private set; }
 
-    public string SteamRoot { get; private set; }
-    public string ProtonPath { get; private set; }
+    public ProtonSettings Proton { get; private set; }
 
     public bool EsyncOn { get; private set; }
     public bool FsyncOn { get; private set; }
@@ -31,12 +30,11 @@ public class WineSettings
     public DirectoryInfo Prefix { get; private set; }
     public DirectoryInfo ProtonPrefix { get; private set; }
 
-    public WineSettings(WineStartupType? startupType, string customBinPath, string steamRoot, string protonPath, string debugVars, FileInfo logFile, DirectoryInfo prefix, DirectoryInfo protonPrefix, bool? esyncOn, bool? fsyncOn)
+    public WineSettings(WineStartupType? startupType, string customBinPath, ProtonSettings protonSettings, string debugVars, FileInfo logFile, DirectoryInfo prefix, DirectoryInfo protonPrefix, bool? esyncOn, bool? fsyncOn)
     {
         this.StartupType = startupType ?? WineStartupType.Custom;
         this.CustomBinPath = customBinPath;
-        this.SteamRoot = steamRoot;
-        this.ProtonPath = protonPath;
+        this.Proton = protonSettings;
         this.EsyncOn = esyncOn ?? false;
         this.FsyncOn = fsyncOn ?? false;
         this.DebugVars = debugVars;
@@ -46,8 +44,8 @@ public class WineSettings
     }
 
     public WineSettings(WineStartupType? startupType, string customBinPath, string debugVars, FileInfo logFile, DirectoryInfo prefix, bool? esyncOn, bool? fsyncOn)
-        : this(startupType, customBinPath, Path.Combine(System.Environment.GetEnvironmentVariable("HOME"),".steam","root"),
-            Path.Combine(System.Environment.GetEnvironmentVariable("HOME"),".steam","root","steamapps","common","Proton 7.0"),
+        : this(startupType, customBinPath, new ProtonSettings(Path.Combine(System.Environment.GetEnvironmentVariable("HOME"),".steam","root"),
+            Path.Combine(System.Environment.GetEnvironmentVariable("HOME"),".steam","root","steamapps","common","Proton 7.0")),
             debugVars, logFile, prefix, new DirectoryInfo(Path.Combine(prefix.Parent.FullName,"protonprefix")), esyncOn, fsyncOn)
     {    }
 }

--- a/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
@@ -73,7 +73,7 @@ public class UnixDalamudRunner : IDalamudRunner
         launchArguments.Add("--");
         launchArguments.Add(gameArgs);
        
-        var dalamudProcess = compatibility.RunInPrefix(string.Join(" ", launchArguments), environment: environment, redirectOutput: true, writeLog: true, inject: false);
+        var dalamudProcess = compatibility.RunInPrefix(string.Join(" ", launchArguments), environment: environment, redirectOutput: true, writeLog: true);
         var output = dalamudProcess.StandardOutput.ReadLine();
         if (output == null && !compatibility.UseProton)
             throw new DalamudRunnerException("An internal Dalamud error has occured");

--- a/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
@@ -92,27 +92,34 @@ public class UnixDalamudRunner : IDalamudRunner
 
         }).Start();
 
-        try
+        // If using proton, the dalamudProcess will output gibberish or nothing, so we'll get unix pid by name.
+        if (compatibility.useProton)
         {
             var unixPid = compatibility.GetUnixProcessIdByName(gameExe.Name);
-            Log.Information($"Got Unix PID: {unixPid}");
-/*          var dalamudConsoleOutput = JsonConvert.DeserializeObject<DalamudConsoleOutput>(output);
-            var unixPid = compatibility.GetUnixProcessId(dalamudConsoleOutput.Pid);
-            Log.Information($"First attempt at Unix Process ID: {unixPid}");
-            if (unixPid == 0) {
-                Log.Information($"That didn't work. Attempting to get by name: {gameExe.Name}");
-                unixPid = compatibility.GetUnixProcessIdByName(gameExe.Name);
-                Log.Information($"Second attempt at Unix Process ID: {unixPid}");
+            if (unixPid == 0)
+            {
+                Log.Error("Could not retrieve Unix process ID by name. Proton did not run correctly.");
+                return null;
             }
+            var gameProcess = Process.GetProcessById(unixPid);
+            Log.Information($"Got game process handle {gameProcess.Handle} with Unix pid {gameProcess.Id}"); //and Wine pid {dalamudConsoleOutput.Pid}");
+            return gameProcess;
+        }
+
+        try
+        {
+            var dalamudConsoleOutput = JsonConvert.DeserializeObject<DalamudConsoleOutput>(output);
+            var unixPid = compatibility.GetUnixProcessId(dalamudConsoleOutput.Pid);
+            if (unixPid == 0) unixPid = compatibility.GetUnixProcessIdByName(gameExe.Name);
 
             if (unixPid == 0)
             {
                 Log.Error("Could not retrive Unix process ID, this feature currently requires a patched wine version");
                 return null;
             }
-*/
+
             var gameProcess = Process.GetProcessById(unixPid);
-            Log.Information($"Got game process handle {gameProcess.Handle} with Unix pid {gameProcess.Id}"); //and Wine pid {dalamudConsoleOutput.Pid}");
+            Log.Information($"Got game process handle {gameProcess.Handle} with Unix pid {gameProcess.Id} and Wine pid {dalamudConsoleOutput.Pid}");
             return gameProcess;
         }
         catch (JsonReaderException ex)

--- a/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
@@ -73,27 +73,26 @@ public class UnixDalamudRunner : IDalamudRunner
         launchArguments.Add("--");
         launchArguments.Add(gameArgs);
        
-        var dalamudProcess = compatibility.RunInPrefix(string.Join(" ", launchArguments), environment: environment, redirectOutput: true, writeLog: true);
+        var dalamudProcess = compatibility.RunInPrefix(string.Join(" ", launchArguments), environment: environment, redirectOutput: true, writeLog: true, inject: false);
         var output = dalamudProcess.StandardOutput.ReadLine();
-        if (output == null && !compatibility.useProton)
+        if (output == null && !compatibility.UseProton)
             throw new DalamudRunnerException("An internal Dalamud error has occured");
 
-        Console.WriteLine("DALAMUD: " + output);
-
+        Console.WriteLine("DALAMUD " + output);
         new Thread(() =>
         {
             while (!dalamudProcess.StandardOutput.EndOfStream)
             {
                 var output = dalamudProcess.StandardOutput.ReadLine();
-                if (output != null) // && !compatibility.useProton)
-                    Console.WriteLine("DALAMUD: " + output);
+                if (output != null) // && !compatibility.UseProton)
+                    Console.WriteLine("DALAMUD " + output);
             }
 
         }).Start();
 
         // If using proton, the dalamudProcess will output gibberish or nothing, so we'll get unix pid by name.
         // Dalamud won't launch the DalamudCrashHandler, but XIVLauncher will close when ffxiv exits.
-        if (compatibility.useProton)
+        if (compatibility.UseProton)
         {
             Log.Information($"Trying to get Unix Process Id of {gameExe.Name}");
             var unixPid = compatibility.GetUnixProcessIdByName(gameExe.Name);

--- a/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
@@ -96,8 +96,7 @@ public class UnixDalamudRunner : IDalamudRunner
         {
             var unixPid = compatibility.GetUnixProcessIdByName(gameExe.Name);
             Log.Information($"Got Unix PID: {unixPid}");
-            Console.Write($"~~~~~~~~~~\n\nGot Unix PID: {unixPid}\n\n~~~~~~~~~~\n");
-/*            var dalamudConsoleOutput = JsonConvert.DeserializeObject<DalamudConsoleOutput>(output);
+/*          var dalamudConsoleOutput = JsonConvert.DeserializeObject<DalamudConsoleOutput>(output);
             var unixPid = compatibility.GetUnixProcessId(dalamudConsoleOutput.Pid);
             Log.Information($"First attempt at Unix Process ID: {unixPid}");
             if (unixPid == 0) {

--- a/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
@@ -94,18 +94,26 @@ public class UnixDalamudRunner : IDalamudRunner
 
         try
         {
-            var dalamudConsoleOutput = JsonConvert.DeserializeObject<DalamudConsoleOutput>(output);
+            var unixPid = compatibility.GetUnixProcessIdByName(gameExe.Name);
+            Log.Information($"Got Unix PID: {unixPid}");
+            Console.Write($"~~~~~~~~~~\n\nGot Unix PID: {unixPid}\n\n~~~~~~~~~~\n");
+/*            var dalamudConsoleOutput = JsonConvert.DeserializeObject<DalamudConsoleOutput>(output);
             var unixPid = compatibility.GetUnixProcessId(dalamudConsoleOutput.Pid);
-            if (unixPid == 0) unixPid = compatibility.GetUnixProcessIdByName(gameExe.Name);
+            Log.Information($"First attempt at Unix Process ID: {unixPid}");
+            if (unixPid == 0) {
+                Log.Information($"That didn't work. Attempting to get by name: {gameExe.Name}");
+                unixPid = compatibility.GetUnixProcessIdByName(gameExe.Name);
+                Log.Information($"Second attempt at Unix Process ID: {unixPid}");
+            }
 
             if (unixPid == 0)
             {
                 Log.Error("Could not retrive Unix process ID, this feature currently requires a patched wine version");
                 return null;
             }
-
+*/
             var gameProcess = Process.GetProcessById(unixPid);
-            Log.Verbose($"Got game process handle {gameProcess.Handle} with Unix pid {gameProcess.Id} and Wine pid {dalamudConsoleOutput.Pid}");
+            Log.Information($"Got game process handle {gameProcess.Handle} with Unix pid {gameProcess.Id}"); //and Wine pid {dalamudConsoleOutput.Pid}");
             return gameProcess;
         }
         catch (JsonReaderException ex)

--- a/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
@@ -96,6 +96,7 @@ public class UnixDalamudRunner : IDalamudRunner
         {
             var dalamudConsoleOutput = JsonConvert.DeserializeObject<DalamudConsoleOutput>(output);
             var unixPid = compatibility.GetUnixProcessId(dalamudConsoleOutput.Pid);
+            if (unixPid == 0) unixPid = compatibility.GetUnixProcessIdByName(gameExe.Name);
 
             if (unixPid == 0)
             {

--- a/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixDalamudRunner.cs
@@ -73,10 +73,17 @@ public class UnixDalamudRunner : IDalamudRunner
         launchArguments.Add("--");
         launchArguments.Add(gameArgs);
 
+        
+
         Log.Information("~~~~~~~~~~~~~~~~~~~~~");
         Log.Information($"Dalamud: {string.Join(" ", launchArguments)}");
         Log.Information("~~~~~~~~~~~~~~~~~~~~~");
-        var dalamudProcess = compatibility.RunInPrefix(string.Join(" ", launchArguments), environment: environment, redirectOutput: true, writeLog: true);
+        
+        Process dalamudProcess;
+        if (!compatibility.useProton)
+            dalamudProcess = compatibility.RunInPrefix(string.Join(" ", launchArguments), environment: environment, redirectOutput: true, writeLog: true);
+        else
+            dalamudProcess = compatibility.RunInProton(string.Join(" ", launchArguments), environment: environment, redirectOutput: true, writeLog: true);
 
         var output = dalamudProcess.StandardOutput.ReadLine();
         if (output == null && !compatibility.useProton)

--- a/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
@@ -23,12 +23,8 @@ public class UnixGameRunner : IGameRunner
     public Process? Start(string path, string workingDirectory, string arguments, IDictionary<string, string> environment, DpiAwareness dpiAwareness)
     {
         if (dalamudOk)
-        {
             return this.dalamudLauncher.Run(new FileInfo(path), arguments, environment);
-        }
-        else
-        {
-            return compatibility.RunInPrefix($"\"{path}\" {arguments}", workingDirectory, environment, writeLog: true);
-        }
+
+        return compatibility.RunInPrefix($"\"{path}\" {arguments}", workingDirectory, environment, writeLog: true);
     }
 }

--- a/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
+++ b/src/XIVLauncher.Common.Unix/UnixGameRunner.cs
@@ -25,6 +25,6 @@ public class UnixGameRunner : IGameRunner
         if (dalamudOk)
             return this.dalamudLauncher.Run(new FileInfo(path), arguments, environment);
 
-        return compatibility.RunInPrefix($"\"{path}\" {arguments}", workingDirectory, environment, writeLog: true);
+        return compatibility.RunInPrefix($"\"{path}\" {arguments}", workingDirectory, environment, writeLog: true, inject: false);
     }
 }


### PR DESCRIPTION
This PR adds the necessary plumbing to use Proton as a runner for launching FFXIV. There are several reasons this is useful.
1. Steam Deck users will automatically have at least one Proton instance, and it will be designed to work with the Steam deck's unique input system.
2. Proton seems to have better support for non-latin character sets. It's possible to get this working with regular wine, but it's a bit tricky.
3. Proton updates fairly frequently, and also has experimental versions and GE-Proton with extra fixes. Since the XIVLauncher.Core changes will just read from steam's directories to find installed proton versions, we don't have to worry about keeping wine up to date. Valve (and GloriousEggroll) will do it for us.
4. This applies to DXVK (and possibly VKD3D in the future) as well. Proton installs maintain their own versions, so we don't have to worry about it. Older GE-Proton also includes dxvk async patches, and the newer ones use DXVK 2.1, which doesn't really need it.
5. Haptic feedback from PS5 controller works with a patched version of proton, but not (easily) with win. It's a nice-to-have feature.

This patch works primarily by modifying the RunInPrefix functions to use "proton runinprefix <command>" instead of "wine <command>" when proton is used. To get around the problem of needing a patched wine, I created a new function to get the unix pid by name. This should always work, unless you manage to launch a second copy of ffxiv_dx11.exe at exactly the right moment. The rest of the changes are just accommidating the proton and steam paths.

This PR is designed to work with a complimentary patch on the XL.Core side. However, if the current 1.0.3.0 is built against this as a submodule, Proton will appear as an option in the Wine Installation Type and will automatically select Proton 7.0. It assumes that Proton 7.0 is installed, and that steam is installed at the usual location of `~/.steam/root`.

Also, ignore the first commit comment about an environment variable and Dalamud not working. The environment variable was removed with the changes to WineSettings, and once I figured out how to get the unix pid by name, Dalamud worked.