### PR TITLE
Add a paste button to OTP Prompt

### DIFF
--- a/src/XIVLauncher/Resources/Loc/XIVLauncher_Localizable.json
+++ b/src/XIVLauncher/Resources/Loc/XIVLauncher_Localizable.json
@@ -751,6 +751,10 @@
     "message": "Enter a valid OTP key.\nIt is 6 digits long.",
     "description": "OtpInputDialogViewModel.SetupLoc"
   },
+  "PasteButton": {
+    "message": "Click here to paste from the clipboard.",
+    "description": "OtpInputDialogViewModel.SetupLoc"
+  },
   "PatchPreparing": {
     "message": "Preparing...",
     "description": "PatchDownloadDialogViewModel.SetupLoc"

--- a/src/XIVLauncher/Windows/OtpInputDialog.xaml
+++ b/src/XIVLauncher/Windows/OtpInputDialog.xaml
@@ -44,15 +44,24 @@
                     </TextBlock>
                 </Grid>
 
-                <TextBox
-                  Margin="0,8,0,10"
-                  HorizontalAlignment="Stretch"
-                  PreviewTextInput="OtpTextBox_OnPreviewTextInput"
-                  PreviewKeyDown="OtpTextBox_PreviewKeyDown"
-                  KeyDown="OtpTextBox_OnKeyDown"
-                  MaxLength="6"
-                  Foreground="{DynamicResource MaterialDesignBody}"
-                  x:Name="OtpTextBox" />
+                <Grid>
+                    <TextBox
+                        Margin="0,8,0,10"
+                        HorizontalAlignment="Stretch"
+                        PreviewTextInput="OtpTextBox_OnPreviewTextInput"
+                        PreviewKeyDown="OtpTextBox_PreviewKeyDown"
+                        KeyDown="OtpTextBox_OnKeyDown"
+                        MaxLength="6"
+                        Foreground="{DynamicResource MaterialDesignBody}"
+                        x:Name="OtpTextBox" />
+                    <Button 
+                        x:Name="PasteButton"
+                        Style="{DynamicResource MaterialDesignFlatButton}"
+                        ToolTip="{Binding PasteButtonLoc}"
+                        HorizontalAlignment="Right" Click="PasteButton_OnClick" Width="32" Padding="4,4,4,4" UseLayoutRounding="False" Margin="1,-10,0,0">
+                        <materialDesign:PackIcon Kind="ContentPaste" Height="24" Width="24"/>
+                    </Button>
+                </Grid>
 
                 <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
                     <Button

--- a/src/XIVLauncher/Windows/OtpInputDialog.xaml.cs
+++ b/src/XIVLauncher/Windows/OtpInputDialog.xaml.cs
@@ -170,6 +170,12 @@ namespace XIVLauncher.Windows
             Cancel();
         }
 
+        private void PasteButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            this.OtpTextBox.Text = Clipboard.GetText();
+            TryAcceptOtp(this.OtpTextBox.Text);
+        }
+
         public void OpenShortcutInfo_MouseUp(object sender, RoutedEventArgs e)
         {
             Process.Start($"https://goatcorp.github.io/faq/mobile_otp");

--- a/src/XIVLauncher/Windows/ViewModel/OtpInputDialogViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/OtpInputDialogViewModel.cs
@@ -16,6 +16,7 @@ namespace XIVLauncher.Windows.ViewModel
             OkLoc = Loc.Localize("OK", "OK");
             OtpOneClickHintLoc = Loc.Localize("OtpOneClickHint", "Or use the app!\r\nClick here to learn more!");
             OtpInputPromptBadLoc = Loc.Localize("OtpInputPromptBad", "Enter a valid OTP key.\nIt is 6 digits long.");
+            PasteButtonLoc = Loc.Localize("PasteButton", "Click here to paste from the clipboard.");
         }
 
         public string OtpInputPromptLoc { get; private set; }
@@ -23,5 +24,6 @@ namespace XIVLauncher.Windows.ViewModel
         public string OkLoc { get; private set; }
         public string OtpOneClickHintLoc { get; private set; }
         public string OtpInputPromptBadLoc { get; private set; }
+        public string PasteButtonLoc { get; private set; }
     }
 }


### PR DESCRIPTION
Adds a clipboard button with some nice hover text. If you click it, it will paste the clipboard into the OTP prompt. 

Assumes XIVLauncher will handle text validation.

![JF0lH](https://user-images.githubusercontent.com/10376708/233814939-16ac7a6a-9608-4789-bbb1-c561ed4a174b.gif)
