### PR TITLE
Always Log OTP Listener

### DIFF
--- a/src/XIVLauncher/Windows/OtpInputDialog.xaml.cs
+++ b/src/XIVLauncher/Windows/OtpInputDialog.xaml.cs
@@ -54,7 +54,7 @@ namespace XIVLauncher.Windows
                 {
                     // Start Listen
                     Task.Run(() => _otpListener.Start());
-                    Log.Debug("OTP server started...");
+                    Log.Information("OTP server started...");
                 }
                 catch (Exception ex)
                 {


### PR DESCRIPTION
This is for troubleshooting purposes, as some users report that it's not starting / doesn't receive, and this will always ensure we know it started.

Just sets the debug log to info.