### PR TITLE
[xlcore][fix] Update mac video files to version 1.1.2

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/GameFixes/Implementations/MacVideoFix.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/GameFixes/Implementations/MacVideoFix.cs
@@ -8,7 +8,7 @@ namespace XIVLauncher.Common.Unix.Compatibility.GameFixes.Implementations;
 
 public class MacVideoFix : GameFix
 {
-    private const string MAC_ZIP_URL = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-1.0.8.zip";
+    private const string MAC_ZIP_URL = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-1.1.2.zip";
 
     public MacVideoFix(DirectoryInfo gameDirectory, DirectoryInfo configDirectory, DirectoryInfo winePrefixDirectory, DirectoryInfo tempDirectory)
         : base(gameDirectory, configDirectory, winePrefixDirectory, tempDirectory)


### PR DESCRIPTION
The mac video files have been updated from 1.0.8 to 1.1.2, and 1.0.8 no longer seems to be on the CDN. This updates the MAC_ZIP_URL to the latest known file.