### PR TITLE
added split button for launch button context menu

### DIFF
--- a/src/XIVLauncher/App.xaml
+++ b/src/XIVLauncher/App.xaml
@@ -16,6 +16,7 @@
                 <!-- Include the Dragablz Material Design style -->
                 <ResourceDictionary Source="pack://application:,,,/Dragablz;component/Themes/materialdesign.xaml"/>                
             </ResourceDictionary.MergedDictionaries>
+            
         </ResourceDictionary>
     </Application.Resources>
 

--- a/src/XIVLauncher/App.xaml
+++ b/src/XIVLauncher/App.xaml
@@ -8,15 +8,16 @@
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Defaults.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Primary/materialdesigncolor.Blue.xaml" />
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignColors;component/Themes/Recommended/Accent/MaterialDesignColor.Blue.xaml" />
-                
+
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.ComboBox.xaml" />
 
                 <ResourceDictionary Source="pack://application:,,,/MaterialDesignThemes.Wpf;component/Themes/MaterialDesignTheme.Dark.xaml" />
 
                 <!-- Include the Dragablz Material Design style -->
-                <ResourceDictionary Source="pack://application:,,,/Dragablz;component/Themes/materialdesign.xaml"/>                
+                <ResourceDictionary Source="pack://application:,,,/Dragablz;component/Themes/materialdesign.xaml"/>
+                <ResourceDictionary Source="Xaml/Components/MaterialDesignOverrides.xaml"/>
             </ResourceDictionary.MergedDictionaries>
-            
+
         </ResourceDictionary>
     </Application.Resources>
 

--- a/src/XIVLauncher/Windows/MainWindow.xaml
+++ b/src/XIVLauncher/Windows/MainWindow.xaml
@@ -279,11 +279,11 @@
                                             <StackPanel Orientation="Horizontal"
                                                         HorizontalAlignment="Center"
                                                         VerticalAlignment="Bottom"
-                                                        Width="142" Margin="0,0,0,0" DockPanel.Dock="Bottom">
+                                                        Width="160" Margin="0,0,0,0" DockPanel.Dock="Bottom">
                                                 <Button
                                                     Content="{Binding LoginLoc}"
                                                     Command="{Binding Path=StartLoginCommand}"
-                                                    Margin="0,0,7,0" Width="84"
+                                                    Margin="0,0,0,0" Width="84"
                                                     ToolTip="{Binding LoginTooltipLoc}">
 
                                                     <Button.ContextMenu>
@@ -304,6 +304,50 @@
                                                     </Button.ContextMenu>
 
                                                 </Button>
+                                                <materialDesign:PopupBox PopupMode="Click"
+                                                                         PlacementMode="BottomAndAlignCentres"
+                                                                         StaysOpen="False"
+                                                                         HorizontalAlignment="Left"
+                                                                         VerticalAlignment="Center"
+                                                                         Margin="0,0,7,0"
+                                                                         >
+
+                                                    <materialDesign:PopupBox.ToggleContent>
+                                                        <StackPanel Orientation="Horizontal">
+                                                            <materialDesign:PackIcon Kind="ChevronDoubleDown" Background="#2196f3"
+                                                        BorderBrush="#2196f3" Foreground="White" Height="32" />
+                                                        </StackPanel>
+
+
+
+                                                    </materialDesign:PopupBox.ToggleContent>
+
+
+                                                <materialDesign:PopupBox.PopupContent>
+                                                        <Menu>
+                                                            
+                                                            <Menu.ItemsPanel>
+                                                                <ItemsPanelTemplate>
+                                                                    <StackPanel />
+                                                                </ItemsPanelTemplate>
+                                                            </Menu.ItemsPanel>
+                                                            <MenuItem Header="{Binding LoginRepairLoc}"
+                                                                      Command="{Binding Path=LoginRepairCommand}" />
+                                                            <Separator/>
+                                                            <MenuItem Header="{Binding LoginNoDalamudLoc}"
+                                                                      Command="{Binding Path=LoginNoDalamudCommand}" />
+                                                            <MenuItem Header="{Binding LoginNoPluginsLoc}"
+                                                                      Command="{Binding Path=LoginNoPluginsCommand}" />
+                                                            <MenuItem Header="{Binding LoginNoThirdLoc}"
+                                                                      Command="{Binding Path=LoginNoThirdCommand}" />
+                                                            <Separator/>
+                                                            <MenuItem Header="{Binding LoginNoStartLoc}"
+                                                                      Command="{Binding Path=LoginNoStartCommand}" />
+                                                            
+                                                            
+                                                        </Menu>
+                                                    </materialDesign:PopupBox.PopupContent>
+                                                </materialDesign:PopupBox>
                                                 <Button HorizontalAlignment="Left"
                                                         x:Name="AccountSwitcherButton" Margin="0 0 0 0"
                                                         Background="#FF0096DB"

--- a/src/XIVLauncher/Windows/MainWindow.xaml
+++ b/src/XIVLauncher/Windows/MainWindow.xaml
@@ -313,14 +313,29 @@
                                                                          >
 
                                                     <materialDesign:PopupBox.ToggleContent>
-                                                        <StackPanel Orientation="Horizontal">
-                                                            <materialDesign:PackIcon Kind="ChevronDoubleDown" Background="#2196f3"
-                                                        BorderBrush="#2196f3" Foreground="White" Height="32" />
-                                                        </StackPanel>
+                                                        <Border Margin="0,0,0,0"
+                                                            BorderBrush="{DynamicResource PrimaryHueMidBrush}"
+                                                            BorderThickness="1" 
+                                                            CornerRadius="2"
+                                                            >
+                                                            <Border.Effect>
+                                                                <DropShadowEffect BlurRadius="2"
+                                                                    Opacity="0.4"
+                                                                    ShadowDepth="2"
+                                                                    Direction="315"/>
+                                                            </Border.Effect>
 
+                                                            <StackPanel Orientation="Horizontal">
+                                                                <materialDesign:PackIcon Kind="ChevronDoubleDown" Background="{DynamicResource PrimaryHueMidBrush}"
+                                                                 Foreground="White" Height="30" />
+                                                            </StackPanel>
+
+                                                        </Border>
+                                                        
 
 
                                                     </materialDesign:PopupBox.ToggleContent>
+                                                
 
 
                                                 <materialDesign:PopupBox.PopupContent>

--- a/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
@@ -1516,6 +1516,7 @@ namespace XIVLauncher.Windows.ViewModel
         public string WaitingForMaintenanceLoc { get; private set; }
         public string CancelWithShortcutLoc { get; private set; }
         public string LoginTooltipLoc { get; private set; }
+        public string LaunchOptionsLoc { get; private set; }
         public string OpenAccountSwitcherLoc { get; private set; }
         public string SettingsLoc { get; private set; }
         public string WorldStatusLoc { get; private set; }

--- a/src/XIVLauncher/Xaml/Components/MaterialDesignOverrides.xaml
+++ b/src/XIVLauncher/Xaml/Components/MaterialDesignOverrides.xaml
@@ -1,0 +1,9 @@
+﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"                                     
+                    xmlns:materialDesign="clr-namespace:MaterialDesignThemes.Wpf;assembly=MaterialDesignThemes.Wpf">
+
+    <Style x:Key="MaterialDesignToggleButtonWithIcon" BasedOn="{StaticResource MaterialDesignFloatingActionButton}" TargetType="{x:Type ToggleButton}">
+        
+    </Style>
+
+</ResourceDictionary>


### PR DESCRIPTION
Added a separate, thin button next to the launch button that, when clicked, displays what it currently the context menu of the launch button. The style of this button is as close to the style of the other buttons as possible, but the drop shadow may be slightly different. Additionally, the context menu of the launch button is still present for the sake of not breaking current behavior

fixes #1337 