### PR TITLE
fix: Update name of redistributable package to download

### DIFF
--- a/src/XIVLauncher/Resources/Loc/XIVLauncher_Localizable.json
+++ b/src/XIVLauncher/Resources/Loc/XIVLauncher_Localizable.json
@@ -567,8 +567,8 @@
     "message": "XIVLauncher is already patching your game in another instance. Please check if XIVLauncher is still open.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "The XIVLauncher in-game addon needs the Microsoft Visual C++ 2015-2019 redistributable to be installed to continue. Please install it from the Microsoft homepage.",
+  "DalamudVc2022RedistError": {
+    "message": "The XIVLauncher in-game addon needs the Microsoft Visual C++ 2015-2022 redistributable to be installed to continue. Please install it from the Microsoft homepage.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Resources/Loc/xl/xl_de.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_de.json
@@ -567,7 +567,7 @@
     "message": "XIVLauncher patcht dein Spiel gerade in einer anderen Instanz. Bitte prüfe, ob es im Hintergrund offen ist.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
+  "DalamudVc2022RedistError": {
     "message": "Das XIVLauncher in-game addon benötigt das Microsoft Visual C++ 2015 Redistributable, um zu starten.\nBitte installiere diese von der Microsoft homepage.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },

--- a/src/XIVLauncher/Resources/Loc/xl/xl_es.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_es.json
@@ -567,8 +567,8 @@
     "message": "XIVLauncher ya está parcheando tu juego en otra ventana. Por favor comprueba si XIVLauncher sigue abierto.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "El addon in-game de XIVLauncher necesita tener instalado Microsoft Visual C++ 2015-2019 redistributable para continuar. Por favor instálalo desde la página principal de Microsoft.",
+  "DalamudVc2022RedistError": {
+    "message": "El addon in-game de XIVLauncher necesita tener instalado Microsoft Visual C++ 2015-2022 redistributable para continuar. Por favor instálalo desde la página principal de Microsoft.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Resources/Loc/xl/xl_fr.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_fr.json
@@ -567,7 +567,7 @@
     "message": "XIVLauncher est déjà en train de mettre à jour votre jeu dans une autre instance. Veuillez vérifier que XIVLauncher est encore ouvert.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
+  "DalamudVc2022RedistError": {
     "message": "L'addon en jeu de XIVLauncher nécessite Microsoft Visual C++ 2015 redistributable d'installé pour continuer.\nVeuillez les installer depuis la page d’accueil Microsoft.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },

--- a/src/XIVLauncher/Resources/Loc/xl/xl_it.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_it.json
@@ -567,8 +567,8 @@
     "message": "XIVLauncher sta già aggiornando il gioco in un'altra istanza. Controlla se XIVLauncher è ancora aperto.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "L'addon in-game di XIVLauncher richiede che il Microsoft Visual C++ 2015-2019 redistributable sia installato per continuare. Installalo dalla homepage di Microsoft.",
+  "DalamudVc2022RedistError": {
+    "message": "L'addon in-game di XIVLauncher richiede che il Microsoft Visual C++ 2015-2022 redistributable sia installato per continuare. Installalo dalla homepage di Microsoft.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Resources/Loc/xl/xl_ja.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_ja.json
@@ -567,7 +567,7 @@
     "message": "他インスタンスでXIVLauncherはもうアップデートを適用しています。他インスタンスをチェックしてください。",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
+  "DalamudVc2022RedistError": {
     "message": "XIVLauncher のin-gameアドオンを利用するには「 Visual Studio 2015、2017、および 2019 用 Microsoft Visual C++ 再頒布可能パッケージ」をインストールする必要があります。続行するには、Microsoft のホームページからインストールしてください。",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },

--- a/src/XIVLauncher/Resources/Loc/xl/xl_ko.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_ko.json
@@ -567,8 +567,8 @@
     "message": "다른 XIVLauncher가 실행 중이고, 패치를 진행하고 있습니다. 다른 XIVLauncher 창이 아직 열려 있는지 확인하십시오.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "XIVLauncher 인게임 애드온을 사용하려면 Microsoft Visual C++ 2015-2019 재배포 가능 패키지가 설치되어 있어야 합니다.\nMicrosoft 공식 홈페이지에서 다운로드하여 설치하십시오.",
+  "DalamudVc2022RedistError": {
+    "message": "XIVLauncher 인게임 애드온을 사용하려면 Microsoft Visual C++ 2015-2022 재배포 가능 패키지가 설치되어 있어야 합니다.\nMicrosoft 공식 홈페이지에서 다운로드하여 설치하십시오.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Resources/Loc/xl/xl_nl.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_nl.json
@@ -567,8 +567,8 @@
     "message": "XIVLauncher is al bezig met het patchen van uw spel in een andere installatie. Controleer of XIVLauncher nog open is.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "De in-game add-on van XIVLauncher heeft de Microsoft Visual C++ 2015-2019 herdistributable nodig om door te gaan. Installeer het vanaf de Microsoft homepage.",
+  "DalamudVc2022RedistError": {
+    "message": "De in-game add-on van XIVLauncher heeft de Microsoft Visual C++ 2015-2022 herdistributable nodig om door te gaan. Installeer het vanaf de Microsoft homepage.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Resources/Loc/xl/xl_no.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_no.json
@@ -567,8 +567,8 @@
     "message": "XIVLauncher oppdaterer allerede spillet ditt i en annen forekomst. Vennligst sjekk om XIVLauncher ennå er åpen.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "Tillegget til XIVLauncher i spillet krever de omdistruerbare Microsoft Visual C++ 2015-2019 pakkene for å fortsette. Vennligst installer dem fra Microsoft's hjemmeside.",
+  "DalamudVc2022RedistError": {
+    "message": "Tillegget til XIVLauncher i spillet krever de omdistruerbare Microsoft Visual C++ 2015-2022 pakkene for å fortsette. Vennligst installer dem fra Microsoft's hjemmeside.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Resources/Loc/xl/xl_pt.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_pt.json
@@ -567,8 +567,8 @@
     "message": "O XIVLauncher já está modificando seu jogo em outra instância. Por favor, verifique se o XIVLauncher ainda está aberto.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "Para funcionar dentro do jogo o addon do XIVLauncher precisa do Microsoft Visual C++ 2015-2019 redistributable instalado. Por favor, instale-o a partir do site da Microsoft.",
+  "DalamudVc2022RedistError": {
+    "message": "Para funcionar dentro do jogo o addon do XIVLauncher precisa do Microsoft Visual C++ 2015-2022 redistributable instalado. Por favor, instale-o a partir do site da Microsoft.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Resources/Loc/xl/xl_ru.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_ru.json
@@ -567,8 +567,8 @@
     "message": "XIVLauncher уже обновляет Вашу игру в другом экземпляре. Пожалуйста, проверьте, открыт ли ещё один XIVLauncher.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "Для работы внутриигровых дополнений XIVLauncher необходимо установить Microsoft Visual C++ 2015-2019. Пожалуйста, установите его с домашней страницы Microsoft.",
+  "DalamudVc2022RedistError": {
+    "message": "Для работы внутриигровых дополнений XIVLauncher необходимо установить Microsoft Visual C++ 2015-2022. Пожалуйста, установите его с домашней страницы Microsoft.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Resources/Loc/xl/xl_si.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_si.json
@@ -567,8 +567,8 @@
     "message": "XIVLauncher is already patching your game in another instance. Please check if XIVLauncher is still open.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "The XIVLauncher in-game addon needs the Microsoft Visual C++ 2015-2019 redistributable to be installed to continue. Please install it from the Microsoft homepage.",
+  "DalamudVc2022RedistError": {
+    "message": "The XIVLauncher in-game addon needs the Microsoft Visual C++ 2015-2022 redistributable to be installed to continue. Please install it from the Microsoft homepage.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Resources/Loc/xl/xl_sv.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_sv.json
@@ -567,8 +567,8 @@
     "message": "XIVLauncher håller redan på att uppdatera ditt spel någon annanstans. Kolla om XIVLauncher fortfarande är öppet.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "XIVLaunchers speltillägg behöver de omfördelbara paketen för Microsoft Visual C++ 2015-2019 att vara installerade för att fortsätta. Var god installera dem från Microsofts hemsida.",
+  "DalamudVc2022RedistError": {
+    "message": "XIVLaunchers speltillägg behöver de omfördelbara paketen för Microsoft Visual C++ 2015-2022 att vara installerade för att fortsätta. Var god installera dem från Microsofts hemsida.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Resources/Loc/xl/xl_tw.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_tw.json
@@ -567,8 +567,8 @@
     "message": "XIVLauncher 正在另一個進程中為您更新遊戲。請檢查您是否啟動了兩個 XIVLauncher。",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "XIVLauncher 遊戲內組件需要安裝 Microsoft Visual C++ 2015-2019 Redistributable 才能啟用。請在微軟官網下載並安裝。",
+  "DalamudVc2022RedistError": {
+    "message": "XIVLauncher 遊戲內組件需要安裝 Microsoft Visual C++ 2015-2022 Redistributable 才能啟用。請在微軟官網下載並安裝。",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Resources/Loc/xl/xl_ur.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_ur.json
@@ -567,8 +567,8 @@
     "message": "XIVLauncher is already patching your game in another instance. Please check if XIVLauncher is still open.",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "The XIVLauncher in-game addon needs the Microsoft Visual C++ 2015-2019 redistributable to be installed to continue. Please install it from the Microsoft homepage.",
+  "DalamudVc2022RedistError": {
+    "message": "The XIVLauncher in-game addon needs the Microsoft Visual C++ 2015-2022 redistributable to be installed to continue. Please install it from the Microsoft homepage.",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Resources/Loc/xl/xl_zh.json
+++ b/src/XIVLauncher/Resources/Loc/xl/xl_zh.json
@@ -567,8 +567,8 @@
     "message": "XIVLauncher 正在另一个进程中为您更新游戏。请检查您是否启动了两个 XIVLauncher。",
     "description": "<RepairGame>d__25.MoveNext"
   },
-  "DalamudVc2019RedistError": {
-    "message": "XIVLauncher 游戏内组件需要安装 Microsoft Visual C++ 2015-2019 Redistributable 才能启用。请在微软官网下载并安装。",
+  "DalamudVc2022RedistError": {
+    "message": "XIVLauncher 游戏内组件需要安装 Microsoft Visual C++ 2015-2022 Redistributable 才能启用。请在微软官网下载并安装。",
     "description": "<StartGameAndAddon>d__29.MoveNext"
   },
   "DalamudArchError": {

--- a/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
@@ -1053,8 +1053,8 @@ namespace XIVLauncher.Windows.ViewModel
                 Log.Error(ex, "No Dalamud Redists found");
 
                 CustomMessageBox.Show(
-                    Loc.Localize("DalamudVc2019RedistError",
-                        "The XIVLauncher in-game addon needs the Microsoft Visual C++ 2015-2019 redistributable to be installed to continue. Please install it from the Microsoft homepage."),
+                    Loc.Localize("DalamudVc2022RedistError",
+                        "The XIVLauncher in-game addon needs the Microsoft Visual C++ 2015-2022 redistributable to be installed to continue. Please install it from the Microsoft homepage."),
                     "XIVLauncher", MessageBoxButton.OK, MessageBoxImage.Exclamation, parentWindow: _window);
             }
             catch (IDalamudCompatibilityCheck.ArchitectureNotSupportedException ex)


### PR DESCRIPTION
Ever since Microsoft released a new version of Visual Studio, there has been a change to the name of the Visual C++ Redistributable. I think it is about time we updated our language, especially since people don't necessarily know that we are telling them outdated information.

This also renames the localisation key. If you don't want that, I can undo that particular change.