### PR TITLE
Copy Dalamud to dev folder recursively

### DIFF
--- a/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
+++ b/src/XIVLauncher.Common/Dalamud/DalamudUpdater.cs
@@ -400,6 +400,15 @@ namespace XIVLauncher.Common.Dalamud
             File.WriteAllText(Path.Combine(addonPath.FullName, "version.json"), info);
         }
 
+        public static void CopyFilesRecursively(DirectoryInfo source, DirectoryInfo target)
+        {
+            foreach (DirectoryInfo dir in source.GetDirectories())
+                CopyFilesRecursively(dir, target.CreateSubdirectory(dir.Name));
+
+            foreach (FileInfo file in source.GetFiles())
+                file.CopyTo(Path.Combine(target.FullName, file.Name));
+        }
+
         private async Task DownloadDalamud(DirectoryInfo addonPath, DalamudVersionInfo version)
         {
             // Ensure directory exists
@@ -433,10 +442,7 @@ namespace XIVLauncher.Common.Dalamud
                     devPath.Create();
                 }
 
-                foreach (var fileInfo in addonPath.GetFiles())
-                {
-                    fileInfo.CopyTo(Path.Combine(devPath.FullName, fileInfo.Name));
-                }
+                CopyFilesRecursively(addonPath, devPath);
             }
             catch (Exception ex)
             {


### PR DESCRIPTION
This fix ensures that the addon folder is copied to the dev folder recursively, so plugin devs can start using the .targets files.

For this to work, I copied over the `CopyFilesRecursively` method from [AssetManager.cs](https://github.com/goatcorp/FFXIVQuickLauncher/blob/6.3.7/src/XIVLauncher.Common/Dalamud/AssetManager.cs#L58-L65). I guess I could’ve also called `AssetManager.CopyFilesRecursively` directly, but that felt like spaghetti code to me.