### PR TITLE
Add YubiKey authentication functionality

### DIFF
--- a/src/XIVLauncher/Accounts/YubiAuth.cs
+++ b/src/XIVLauncher/Accounts/YubiAuth.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Serilog;
+using Yubico.YubiKey;
+using Yubico.YubiKey.Oath;
+using Yubico.PlatformInterop;
+using System.Runtime.InteropServices;
+
+namespace XIVLauncher.Accounts
+{
+    public class YubiAuth
+    {
+        private const string ISSUER = "XIVLauncher";
+        private const string ACCOUNT_NAME = "FFXIV";
+        private const CredentialType AUTH_TYPE = CredentialType.Totp;
+        private const CredentialPeriod TIME_PERIOD = CredentialPeriod.Period30;
+        private const byte NUM_DIGITS = 6;
+
+        private static IYubiKeyDevice _yubiKey;
+        public YubiKeyDeviceListener DeviceListener;
+        public YubiAuth()
+        {
+            FindYubiDevice();
+            DeviceListener = YubiKeyDeviceListener.Instance;
+        }
+
+        //Generates generic credential
+        public Credential BuildCredential()
+        {
+            var credentialTotp = new Credential
+            {
+                Issuer = ISSUER,
+                AccountName = ACCOUNT_NAME,
+                Type = AUTH_TYPE,
+                Period = TIME_PERIOD,
+                Digits = NUM_DIGITS,
+            };
+            return credentialTotp;
+        }
+
+        //Generates credential to be put onto user's YubiKey
+        public Credential BuildCredential(string key, bool useTouch)
+        {
+            var credentialTotp = new Credential
+            {
+                Issuer = ISSUER,
+                AccountName = ACCOUNT_NAME,
+                Type = AUTH_TYPE,
+                Period = TIME_PERIOD,
+                Secret = key,
+                Digits = NUM_DIGITS,
+                RequiresTouch = useTouch,
+            };
+            return credentialTotp;
+        }
+
+        //Finds YubiKey(s) that are plugged into a USB port
+        public void FindYubiDevice()
+        {
+            //Find YubiKey device
+            try
+            {
+                if (_yubiKey == null)
+                {
+                    IEnumerable<IYubiKeyDevice> keys = YubiKeyDevice.FindByTransport(Transport.UsbSmartCard);
+                    SetYubiDevice(keys.First());
+                }
+            }
+            catch (Exception ex) when (ex is ArgumentException || ex is InvalidOperationException)
+            {
+                Log.Debug("No YubiKey device was detected");
+                Log.Debug(ex.ToString());
+            }
+
+        }
+
+        public IYubiKeyDevice GetYubiDevice()
+        {
+            return _yubiKey;
+        }
+
+        public void SetYubiDevice(IYubiKeyDevice yubiKeyDevice)
+        {
+            _yubiKey = yubiKeyDevice;
+        }
+
+        //Checks for existing credentials on user's YubiKey that match the XIVLauncher generic credential
+        public bool CheckForCredential(OathSession session)
+        {
+            try
+            {
+                IList<Credential> creds = session.GetCredentials().Where(credential => credential.Issuer == ISSUER && credential.AccountName == ACCOUNT_NAME).ToList();
+                if (creds != null && creds.Count != 0)
+                {
+                    return true;
+                }
+                return false;
+            }
+            catch (SCardException)
+            {
+                Log.Error("YubiKey was removed during GET operation.");
+                return false;
+            }
+        }
+
+        //Adds the user's credential onto their YubiKey device
+        public void CreateEntry(Credential cred)
+        {
+            try
+            {
+                new OathSession(_yubiKey).AddCredential(cred);
+                Log.Debug("Successfully created new credential " + cred.Name);
+            }
+            catch (SCardException)
+            {
+                Log.Error("YubiKey was removed during ADD operation");
+            }
+
+        }
+
+    }
+
+
+}

--- a/src/XIVLauncher/Directory.Build.targets
+++ b/src/XIVLauncher/Directory.Build.targets
@@ -1,0 +1,31 @@
+<Project>
+	<Choose>
+		<!-- If x86 architecture -->
+		<When Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X86' OR '$(Platform)' == 'x86'">
+			<ItemGroup>
+				<PackageReference Include="Yubico.NativeShims" Version="1.6.1">
+					<PrivateAssets>build</PrivateAssets>
+				</PackageReference>
+				<Content Include="$(NugetPackageRoot)\yubico.nativeshims\1.6.1\runtimes\win-x86\native\Yubico.NativeShims.dll">
+					<Link>Yubico.NativeShims.dll</Link>
+					<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+					<Visible>false</Visible>
+				</Content>
+			</ItemGroup>
+		</When>
+		
+		<!-- If x64 architecture -->
+		<When Condition="'$([System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture)' == 'X64' OR '$(Platform)' == 'x64'">
+			<ItemGroup>
+				<PackageReference Include="Yubico.NativeShims" Version="1.6.1">
+					<PrivateAssets>build</PrivateAssets>
+				</PackageReference>
+				<Content Include="$(NugetPackageRoot)\yubico.nativeshims\1.6.1\runtimes\win-x64\native\Yubico.NativeShims.dll">
+					<Link>Yubico.NativeShims.dll</Link>
+					<CopyToOutputDirectory>Always</CopyToOutputDirectory>
+					<Visible>false</Visible>
+				</Content>
+			</ItemGroup>
+		</When>
+	</Choose>
+</Project>

--- a/src/XIVLauncher/Resources/LICENSE.txt
+++ b/src/XIVLauncher/Resources/LICENSE.txt
@@ -725,3 +725,4 @@ aria2                                     https://github.com/aria2/aria2/blob/ma
 Spooky                                    https://github.com/Yortw/Spooky/blob/master/LICENSE                                    
 AriaNet                                   https://creativecommons.org/licenses/by-nc-sa/3.0/au/                                  
 SharedMemory                              https://github.com/spazzarama/SharedMemory/blob/master/LICENSE.md
+Yubico.NET.SDK                            https://github.com/Yubico/Yubico.NET.SDK/blob/develop/LICENSE.txt

--- a/src/XIVLauncher/Settings/ILauncherSettingsV3.cs
+++ b/src/XIVLauncher/Settings/ILauncherSettingsV3.cs
@@ -21,6 +21,7 @@ namespace XIVLauncher.Settings
         bool InGameAddonEnabled { get; set; }
         DalamudLoadMethod? InGameAddonLoadMethod { get; set; }
         bool OtpServerEnabled { get; set; }
+        bool OtpYubiKeyEnabled { get; set; }
         ClientLanguage? Language { get; set; }
         LauncherLanguage? LauncherLanguage { get; set; }
         string CurrentAccountId { get; set; }

--- a/src/XIVLauncher/Windows/OtpInputDialog.xaml.cs
+++ b/src/XIVLauncher/Windows/OtpInputDialog.xaml.cs
@@ -2,6 +2,7 @@
 using System.Diagnostics;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Input;
@@ -9,8 +10,13 @@ using System.Windows.Media;
 using System.Windows.Media.Animation;
 using System.Windows.Threading;
 using Serilog;
+using XIVLauncher.Accounts;
 using XIVLauncher.Common.Http;
 using XIVLauncher.Windows.ViewModel;
+using Yubico.PlatformInterop;
+using Yubico.YubiKey;
+using Yubico.YubiKey.Oath;
+using Yubico.YubiKey.Oath.Commands;
 
 namespace XIVLauncher.Windows
 {
@@ -28,6 +34,9 @@ namespace XIVLauncher.Windows
         private OtpListener _otpListener;
         private bool _ignoreCurrentOtp;
 
+        private YubiAuth _yubiAuth;
+        private readonly object _lock = new();
+        private Thread _yubiThread;
         public OtpInputDialog()
         {
             InitializeComponent();
@@ -50,6 +59,17 @@ namespace XIVLauncher.Windows
                 _otpListener = new OtpListener("legacy-" + AppUtil.GetAssemblyVersion());
                 _otpListener.OnOtpReceived += TryAcceptOtp;
 
+                if (App.Settings.OtpYubiKeyEnabled)
+                {
+                    _yubiAuth = new YubiAuth();
+                    if (_yubiAuth.DeviceListener != null)
+                    {
+                        _yubiAuth.DeviceListener.Arrived += OnYubiKeyArrived;
+                        _yubiAuth.DeviceListener.Removed += OnYubiKeyRemoved;
+                    }
+                    AttemptYubiAuth();
+                }
+
                 try
                 {
                     // Start Listen
@@ -71,6 +91,15 @@ namespace XIVLauncher.Windows
             OtpInputPrompt.Foreground = _otpInputPromptDefaultBrush;
             OtpTextBox.Text = "";
             OtpTextBox.Focus();
+        }
+        public void ResetPrompt()
+        {
+            Dispatcher.Invoke(() =>
+            {
+                OtpInputPrompt.Text = ViewModel.OtpInputPromptLoc;
+                OtpInputPrompt.Foreground = _otpInputPromptDefaultBrush;
+                OtpTextBox.Focus();
+            });
         }
 
         public void IgnoreCurrentResult(string reason)
@@ -114,6 +143,7 @@ namespace XIVLauncher.Windows
                 else
                 {
                     _otpListener?.Stop();
+                    CleanupYubi();
                     DialogResult = true;
                     Hide();
                 }
@@ -124,8 +154,18 @@ namespace XIVLauncher.Windows
         {
             OnResult?.Invoke(null);
             _otpListener?.Stop();
+            CleanupYubi();
             DialogResult = false;
             Hide();
+        }
+        private void CleanupYubi()
+        {
+            if (_yubiAuth != null)
+            {
+                _yubiAuth.DeviceListener.Arrived -= OnYubiKeyArrived;
+                _yubiAuth.DeviceListener.Removed -= OnYubiKeyRemoved;
+                _yubiThread?.Abort();
+            }
         }
 
         private void OtpInputDialog_OnMouseMove(object sender, MouseEventArgs e)
@@ -174,6 +214,121 @@ namespace XIVLauncher.Windows
         {
             this.OtpTextBox.Text = Clipboard.GetText();
             TryAcceptOtp(this.OtpTextBox.Text);
+        }
+        private void OnYubiKeyArrived(object sender, YubiKeyDeviceEventArgs e)
+        {
+            Log.Debug("YubiKey found! " + e.Device.ToString());
+            _yubiAuth.SetYubiDevice(e.Device);
+            AttemptYubiAuth();
+        }
+
+        private void OnYubiKeyRemoved(object sender, YubiKeyDeviceEventArgs e)
+        {
+            Log.Debug("YubiKey removed!");
+            _yubiAuth.SetYubiDevice(null);
+            ResetPrompt();
+        }
+
+        private void AttemptYubiAuth()
+        {
+            if (_yubiAuth.GetYubiDevice() == null)
+            {
+                return;
+            }
+
+            OathSession session = new OathSession(_yubiAuth.GetYubiDevice());
+            var totp = _yubiAuth.BuildCredential();
+
+            try
+            {
+                //Set prompt respectively
+                Dispatcher.Invoke(() =>
+                {
+                    if (_yubiAuth.CheckForCredential(session) == true)
+                    {
+                        OtpInputPrompt.Text = ViewModel.OtpInputPromptYubiLoc;
+                        OtpInputPrompt.Foreground = Brushes.LightGreen;
+                        Storyboard myStoryboard = (Storyboard)OtpInputPrompt.Resources["InvalidShake"];
+                        Storyboard.SetTarget(myStoryboard.Children.ElementAt(0), OtpInputPrompt);
+                        myStoryboard.Begin();
+                        OtpTextBox.Focus();
+                    }
+                    else
+                    {
+                        OtpInputPrompt.Text = ViewModel.OtpInputPromptYubiBadLoc;
+                        OtpInputPrompt.Foreground = Brushes.Red;
+                        Storyboard myStoryboard = (Storyboard)OtpInputPrompt.Resources["InvalidShake"];
+                        Storyboard.SetTarget(myStoryboard.Children.ElementAt(0), OtpInputPrompt);
+                        myStoryboard.Begin();
+                        OtpTextBox.Focus();
+                        return;
+                    }
+                });
+
+            }
+            catch (SCardException)
+            {
+                Log.Error("YubiKey was removed while performing operation.");
+                return;
+            }
+
+
+            byte retries = 0;
+            _yubiThread = new Thread(() =>
+            {
+                //Handle touch-based authentication, gives user three attempts to touch YubiKey
+                //Attempts are approximately 15 seconds by defualt
+                while (retries < 3 && _yubiAuth.GetYubiDevice() != null)
+                {
+                    CalculateCredentialResponse ccr = null;
+                    try
+                    {
+                        //Attempts to generate otp and then login
+                        CalculateCredentialCommand ccd = new CalculateCredentialCommand(totp, ResponseFormat.Truncated);
+                        ccr = session.Connection.SendCommand(ccd);
+
+                        Log.Debug("Status: " + ccr.Status);
+                        Log.Debug("Status Message: " + ccr.StatusMessage);
+                        Log.Debug("Data: " + ccr.GetData().Value);
+                        TryAcceptOtp(ccr.GetData().Value);
+                        break;
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        Log.Debug(ex.Message);
+
+                        retries++;
+
+                        //Handle authentication timeout
+                        if (ccr != null)
+                        {
+                            Log.Debug("Status: " + ccr.Status);
+                            Log.Debug("Status Message: " + ccr.StatusMessage);
+                        }
+
+                        if (retries == 3)
+                        {
+                            Dispatcher.Invoke(() =>
+                            {
+                                OtpInputPrompt.Text = ViewModel.OtpInputPromptYubiTimeoutLoc;
+                                OtpInputPrompt.Foreground = Brushes.Red;
+                                Storyboard myStoryboard = (Storyboard)OtpInputPrompt.Resources["InvalidShake"];
+                                Storyboard.SetTarget(myStoryboard.Children.ElementAt(0), OtpInputPrompt);
+                                myStoryboard.Begin();
+                                OtpTextBox.Focus();
+                            });
+                            break;
+                        }
+                    }
+                    catch (SCardException)
+                    {
+                        Log.Error("YubiKey was removed during authentication attempt.");
+                        break;
+                    }
+                }
+            });
+            _yubiThread.Start();
+            
         }
 
         public void OpenShortcutInfo_MouseUp(object sender, RoutedEventArgs e)

--- a/src/XIVLauncher/Windows/SecurityKeySetupDialog.xaml
+++ b/src/XIVLauncher/Windows/SecurityKeySetupDialog.xaml
@@ -1,0 +1,75 @@
+﻿<Window x:Class="XIVLauncher.Windows.SecurityKeySetupDialog"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        xmlns:materialDesign="http://materialdesigninxaml.net/winfx/xaml/themes"
+        mc:Ignorable="d"
+        Title="Enter Authentication Key" WindowStartupLocation="CenterScreen"
+        Icon="pack://application:,,,/Resources/dalamud_icon.ico" ResizeMode="NoResize"
+        TextElement.Foreground="{DynamicResource MaterialDesignBody}"
+        TextElement.FontWeight="Medium"
+        FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto"
+        AllowsTransparency="True"
+        Background="Transparent"
+        WindowStyle="None" Height="198.088" Width="325.186">
+    <Grid Margin="0,0,0,0">
+        <materialDesign:Card Background="{DynamicResource MaterialDesignPaper}" Height="182" Margin="0,0,10,0">
+            <StackPanel Margin="10,10,10,0">
+                <Grid
+                    HorizontalAlignment="Stretch"
+                    Height="32">
+                    <TextBlock
+                        Foreground="{DynamicResource MaterialDesignBody}"
+                        Text="{Binding KeySetupInputPromptInsertLoc}"
+                        TextAlignment="Center"
+                        HorizontalAlignment="Center"
+                        VerticalAlignment="Center"
+                        x:Name="KeySetupInputPrompt">
+                        <TextBlock.Resources>
+                            <Storyboard x:Key="InvalidShake">
+                                <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="RenderTransform.(TranslateTransform.X)">
+                                    <EasingDoubleKeyFrame KeyTime="0:0:0.0" Value="10"/>
+                                    <EasingDoubleKeyFrame KeyTime="0:0:0.1" Value="-7"/>
+                                    <EasingDoubleKeyFrame KeyTime="0:0:0.2" Value="5"/>
+                                    <EasingDoubleKeyFrame KeyTime="0:0:0.3" Value="-3"/>
+                                    <EasingDoubleKeyFrame KeyTime="0:0:0.4" Value="1"/>
+                                    <EasingDoubleKeyFrame KeyTime="0:0:0.5" Value="0"/>
+                                </DoubleAnimationUsingKeyFrames>
+                            </Storyboard>
+                        </TextBlock.Resources>
+                        <TextBlock.RenderTransform>
+                            <TranslateTransform X="0" Y="0" />
+                        </TextBlock.RenderTransform>
+                    </TextBlock>
+                </Grid>
+
+                <TextBox
+                    Margin="0,8,0,10"
+                    HorizontalAlignment="Stretch"
+                    PreviewTextInput="KeySetupTextBox_OnPreviewTextInput"
+                    PreviewKeyDown="KeySetupTextBox_PreviewKeyDown"
+                    KeyDown="KeySetupTextBox_OnKeyDown"
+                    MaxLength="32"
+                    Foreground="{DynamicResource MaterialDesignBody}"
+                    x:Name="KeySetupTextBox" TextChanged="KeySetupTextBox_TextChanged" />
+                <CheckBox Foreground="{DynamicResource MaterialDesignBody}"
+                                  x:Name="KeySetupTouchCheckBox" Content="{Binding KeySetupCheckBoxLoc}" ToolTip="{Binding KeySetupTooltipLoc}"/>
+                
+                <StackPanel Orientation="Horizontal" HorizontalAlignment="Center" Margin="0,10,0,0">
+                    <Button
+                        Content="{Binding OkLoc}"
+                        Margin="10,0,0,0"
+                        Width="100"
+                        Click="OkButton_OnClick" />
+                    <Button
+                        Content="{Binding CancelWithShortcutLoc}"
+                        Margin="7,0,0,0"
+                        Width="100"
+                        Click="CancelButton_OnClick" />
+                </StackPanel>
+                <TextBlock Foreground="DarkGray" Margin="0,8,0,0" TextAlignment="Center" Cursor="Hand" MouseUp="OpenShortcutInfo_MouseUp" Text="{Binding KeySetupOnClickHintLoc}"/>
+            </StackPanel>
+        </materialDesign:Card>
+    </Grid>
+</Window>

--- a/src/XIVLauncher/Windows/SecurityKeySetupDialog.xaml.cs
+++ b/src/XIVLauncher/Windows/SecurityKeySetupDialog.xaml.cs
@@ -1,0 +1,242 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Text.RegularExpressions;
+using System.Windows;
+using System.Windows.Input;
+using System.Windows.Media;
+using System.Windows.Media.Animation;
+using System.Windows.Threading;
+using Serilog;
+using XIVLauncher.Accounts;
+using XIVLauncher.Windows.ViewModel;
+using Yubico.YubiKey;
+
+namespace XIVLauncher.Windows
+{
+    /// <summary>
+    /// Interaction logic for SecurityKeySetupDialog.xaml
+    /// </summary>
+    public partial class SecurityKeySetupDialog : Window
+    {
+        public event Action<string> OnResult;
+
+        private readonly Brush _setupPromptDefaultBrush;
+
+        private SecurityKeySetupDialogViewModel ViewModel => DataContext as SecurityKeySetupDialogViewModel;
+
+        private YubiAuth _yubiAuth;
+
+        public SecurityKeySetupDialog()
+        {
+            InitializeComponent();
+            _setupPromptDefaultBrush = KeySetupInputPrompt.Foreground;
+
+            this.DataContext = new SecurityKeySetupDialogViewModel();
+            DataObject.AddPastingHandler(KeySetupTextBox, KeySetupTextBox_OnPaste);
+
+            MouseMove += KeySetupDialog_OnMouseMove;
+            Activated += (_, _) => KeySetupTextBox.Focus();
+            GotFocus += (_, _) => KeySetupTextBox.Focus();
+        }
+
+        public new bool? ShowDialog()
+        {
+            KeySetupTextBox.Focus();
+
+            _yubiAuth = new YubiAuth();
+            if (_yubiAuth.GetYubiDevice() != null)
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    KeySetupInputPrompt.Text = ViewModel.KeySetupInputPromptYubiLoc;
+                    KeySetupInputPrompt.Foreground = Brushes.LightGreen;
+                    Storyboard myStoryboard = (Storyboard)KeySetupInputPrompt.Resources["InvalidShake"];
+                    Storyboard.SetTarget(myStoryboard.Children.ElementAt(0), KeySetupInputPrompt);
+                    myStoryboard.Begin();
+                    KeySetupTextBox.Focus();
+                });
+            }
+            SetupYubiListener();
+            return base.ShowDialog();
+        }
+
+        private void SetupYubiListener()
+        {
+            if(_yubiAuth.DeviceListener != null)
+            {
+                _yubiAuth.DeviceListener.Arrived += OnYubiKeyArrived;
+                _yubiAuth.DeviceListener.Removed += OnYubiKeyRemoved;
+            }
+        }
+
+        private void OnYubiKeyArrived(object sender, YubiKeyDeviceEventArgs e)
+        {
+            Log.Debug("YubiKey arrived! " + e.Device.ToString());
+            _yubiAuth.SetYubiDevice(e.Device);
+            ResetPrompt();
+        }
+
+        private void OnYubiKeyRemoved(object sender, YubiKeyDeviceEventArgs e)
+        {
+            Log.Debug("YubiKey removed! " + e.Device.ToString());
+            _yubiAuth.SetYubiDevice(null);
+            ResetPrompt();
+        }
+        public void ResetPrompt()
+        {
+            Dispatcher.Invoke(() =>
+            {
+                if (_yubiAuth.GetYubiDevice() == null)
+                {
+                    KeySetupInputPrompt.Text = ViewModel.KeySetupInputPromptInsertLoc;
+                    KeySetupInputPrompt.Foreground = _setupPromptDefaultBrush;
+                    KeySetupTextBox.Focus();
+                }
+                else
+                {
+                    KeySetupInputPrompt.Text = ViewModel.KeySetupInputPromptYubiLoc;
+                    KeySetupInputPrompt.Foreground = Brushes.LightGreen;
+                    Storyboard myStoryboard = (Storyboard)KeySetupInputPrompt.Resources["InvalidShake"];
+                    Storyboard.SetTarget(myStoryboard.Children.ElementAt(0), KeySetupInputPrompt);
+                    myStoryboard.Begin();
+                    KeySetupTextBox.Focus();
+                }
+            });
+
+        }
+        private void Cancel()
+        {
+            DialogResult = false;
+            CleanupYubi();
+            OnResult?.Invoke(null);
+            Hide();
+        }
+        private void CleanupYubi()
+        {
+            if (_yubiAuth.DeviceListener != null)
+            {
+                _yubiAuth.DeviceListener.Arrived -= OnYubiKeyArrived;
+                _yubiAuth.DeviceListener.Removed -= OnYubiKeyRemoved;
+            }
+        }
+
+        public void TryAcceptKey(string key)
+        {
+            if (key.Length < 32 || Regex.IsMatch(key, "[^A-Za-z2-7=]+"))
+            {
+                Log.Error("Malformed Authentication Key: {Key}", key);
+
+                Dispatcher.Invoke(() =>
+                {
+                    KeySetupInputPrompt.Text = ViewModel.KeySetupInputPromptBadLoc;
+                    KeySetupInputPrompt.Foreground = Brushes.Red;
+                    Storyboard myStoryboard = (Storyboard)KeySetupInputPrompt.Resources["InvalidShake"];
+                    Storyboard.SetTarget(myStoryboard.Children.ElementAt(0), KeySetupInputPrompt);
+                    myStoryboard.Begin();
+                    KeySetupTextBox.Focus();
+                });
+
+                return;
+            }
+
+            var credential = _yubiAuth.BuildCredential(key, KeySetupTouchCheckBox.IsChecked.GetValueOrDefault());
+            _yubiAuth.CreateEntry(credential);
+            DialogResult = true;
+            CleanupYubi();
+            OnResult?.Invoke(credential.Name);
+            Hide();
+        }
+
+        private void KeySetupDialog_OnMouseMove(object sender, MouseEventArgs e)
+        {
+            if (e.LeftButton == MouseButtonState.Pressed)
+                DragMove();
+        }
+
+        private void KeySetupTextBox_OnPreviewTextInput(object sender, TextCompositionEventArgs e)
+        {
+            var regex = new Regex("[^A-Za-z2-7=]+");
+            e.Handled = regex.IsMatch(e.Text);
+        }
+
+        private void KeySetupTextBox_PreviewKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Space)
+            {
+                e.Handled = true;
+            }
+        }
+
+        private void KeySetupTextBox_OnKeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.Key == Key.Escape)
+            {
+                Cancel();
+            }
+            else if (e.Key == Key.Enter)
+            {
+                TryAcceptKey(this.KeySetupTextBox.Text);
+            }
+        }
+
+        private void OkButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            if (_yubiAuth.GetYubiDevice() == null)
+            {
+                Dispatcher.Invoke(() =>
+                {
+                    KeySetupInputPrompt.Text = ViewModel.KeySetupInputPromptInsertLoc;
+                    KeySetupInputPrompt.Foreground = Brushes.Red;
+                    Storyboard myStoryboard = (Storyboard)KeySetupInputPrompt.Resources["InvalidShake"];
+                    Storyboard.SetTarget(myStoryboard.Children.ElementAt(0), KeySetupInputPrompt);
+                    myStoryboard.Begin();
+                    KeySetupTextBox.Focus();
+                });
+                return;
+            }
+
+            TryAcceptKey(this.KeySetupTextBox.Text);
+        }
+
+        private void CancelButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            Cancel();
+        }
+
+        public void OpenShortcutInfo_MouseUp(object sender, RoutedEventArgs e)
+        {
+            Process.Start($"https://goatcorp.github.io/faq/yubikey");
+        }
+
+        public static string AskForKey(Action<SecurityKeySetupDialog, string> onResult, Window parentWindow)
+        {
+            if (Dispatcher.CurrentDispatcher != parentWindow.Dispatcher)
+                return parentWindow.Dispatcher.Invoke(() => AskForKey(onResult, parentWindow));
+
+            var dialog = new SecurityKeySetupDialog();
+            if (parentWindow.IsVisible)
+            {
+                dialog.Owner = parentWindow;
+                dialog.ShowInTaskbar = false;
+            }
+
+            string result = null;
+            dialog.OnResult += credName => onResult(dialog, result = credName);
+            return dialog.ShowDialog() == true ? result : null;
+        }
+        private void KeySetupTextBox_OnPaste(object sender, DataObjectPastingEventArgs e)
+        {
+            var isText = e.SourceDataObject.GetDataPresent(DataFormats.UnicodeText, true);
+            if (!isText) return;
+
+            var text = e.SourceDataObject.GetData(DataFormats.UnicodeText) as string;
+            text = text.Replace(" ", "");
+            KeySetupTextBox.Text = text;
+        }
+        private void KeySetupTextBox_TextChanged(object sender, System.Windows.Controls.TextChangedEventArgs e)
+        {
+
+        }
+    }
+}

--- a/src/XIVLauncher/Windows/SettingsControl.xaml
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml
@@ -52,6 +52,33 @@
                         </Button>
                     </StackPanel>
 
+                    <StackPanel Orientation="Horizontal" Margin="20,5,0,0">
+                        <CheckBox Foreground="{DynamicResource MaterialDesignBody}"
+                                  x:Name="OtpYubiKeyCheckBox" Content="{Binding OtpYubiKeyCheckBoxLoc}" ToolTip="{Binding OtpYubiKeyTooltipLoc}"  IsEnabled="{Binding ElementName=OtpServerCheckBox, Path=IsChecked}"/>
+
+                        <Button Style="{DynamicResource MaterialDesignFlatButton}"
+                                HorizontalAlignment="Left" Click="YubiKeySetupAuthButton_OnClick" Margin="0 0 0 0">
+                            <Button.ToolTip>
+                                <TextBlock Text="{Binding OtpSetupAuthTooltipLoc}" />
+                            </Button.ToolTip>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock VerticalAlignment="Center"
+                                           Foreground="LightBlue" FontSize="11" Text="{Binding OtpSetupAuthLoc}"/>
+                            </StackPanel>
+                        </Button>
+                        
+                        <Button Style="{DynamicResource MaterialDesignFlatButton}"
+                                HorizontalAlignment="Left" Click="LearnMoreYubiKeyButton_OnClick" Margin="5 0 0 0">
+                            <Button.ToolTip>
+                                <TextBlock Text="{Binding OtpLearnMoreTooltipLoc}" />
+                            </Button.ToolTip>
+                            <StackPanel Orientation="Horizontal">
+                                <TextBlock VerticalAlignment="Center"
+                                           Foreground="DarkGray" FontSize="11" Text="{Binding LearnMoreLoc}"/>
+                            </StackPanel>
+                        </Button>
+                    </StackPanel>
+
                     <CheckBox Foreground="{DynamicResource MaterialDesignBody}"
                               x:Name="AutoStartSteamCheckBox" Margin="0,15,0,0" Content="{Binding AutoStartSteamLoc}" ToolTip="{Binding AutoStartSteamTooltipLoc}" />
                     

--- a/src/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -87,6 +87,12 @@ namespace XIVLauncher.Windows
 
             OtpServerCheckBox.IsChecked = App.Settings.OtpServerEnabled;
 
+            if (OtpServerCheckBox.IsChecked == true)
+                OtpYubiKeyCheckBox.IsChecked = App.Settings.OtpYubiKeyEnabled;
+            else
+                OtpYubiKeyCheckBox.IsChecked = false;
+
+
             LaunchArgsTextBox.Text = App.Settings.AdditionalLaunchArgs;
 
             DpiAwarenessComboBox.SelectedIndex = (int) App.Settings.DpiAwareness.GetValueOrDefault(DpiAwareness.Unaware);
@@ -136,6 +142,8 @@ namespace XIVLauncher.Windows
                 App.Settings.InGameAddonLoadMethod = DalamudLoadMethod.EntryPoint;
 
             App.Settings.OtpServerEnabled = OtpServerCheckBox.IsChecked == true;
+
+            App.Settings.OtpYubiKeyEnabled = OtpYubiKeyCheckBox.IsChecked == true;
 
             App.Settings.AdditionalLaunchArgs = LaunchArgsTextBox.Text;
 
@@ -434,6 +442,23 @@ namespace XIVLauncher.Windows
         private void LearnMoreButton_OnClick(object sender, RoutedEventArgs e)
         {
             PlatformHelpers.OpenBrowser("https://goatcorp.github.io/faq/mobile_otp");
+        }
+        private void LearnMoreYubiKeyButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            PlatformHelpers.OpenBrowser("https://goatcorp.github.io/faq/yubikey");
+        }
+        private void YubiKeySetupAuthButton_OnClick(object sender, RoutedEventArgs e)
+        {
+            var authKey = string.Empty;
+            authKey = SecurityKeySetupDialog.AskForKey((securityKeySetupDialog, result) =>
+            {
+                if (securityKeySetupDialog.DialogResult == true)
+                {
+                    CustomMessageBox.Show(Loc.Localize("SetupAuthSuccess", $"YubiKey account \"{result}\" has been successfully created.\nYou may now use this YubiKey alongside XIVLauncher."),
+                    "XIVLauncher - YubiKey Setup", image: MessageBoxImage.Information, showDiscordLink: false, showHelpLinks: false);
+                }
+            }, Window.GetWindow(this));
+            
         }
 
         private void IsFreeTrialCheckbox_OnClick(object sender, RoutedEventArgs e)

--- a/src/XIVLauncher/Windows/ViewModel/OtpInputDialogViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/OtpInputDialogViewModel.cs
@@ -17,6 +17,9 @@ namespace XIVLauncher.Windows.ViewModel
             OtpOneClickHintLoc = Loc.Localize("OtpOneClickHint", "Or use the app!\r\nClick here to learn more!");
             OtpInputPromptBadLoc = Loc.Localize("OtpInputPromptBad", "Enter a valid OTP key.\nIt is 6 digits long.");
             PasteButtonLoc = Loc.Localize("PasteButton", "Click here to paste from the clipboard.");
+            OtpInputPromptYubiLoc = Loc.Localize("OtpInputPromptYubi", "Found a valid Yubikey, touch it to login.");
+            OtpInputPromptYubiBadLoc = Loc.Localize("OtpInputPromptYubiBad", "Yubikey has not been setup yet.\nCheck Settings to complete setup.");
+            OtpInputPromptYubiTimeoutLoc = Loc.Localize("OtpInputPromptYubiTimeout", "YubiKey timed out\nEnter your OTP or reinsert the YubiKey.");
         }
 
         public string OtpInputPromptLoc { get; private set; }
@@ -25,5 +28,8 @@ namespace XIVLauncher.Windows.ViewModel
         public string OtpOneClickHintLoc { get; private set; }
         public string OtpInputPromptBadLoc { get; private set; }
         public string PasteButtonLoc { get; private set; }
+        public string OtpInputPromptYubiLoc { get; private set; }
+        public string OtpInputPromptYubiBadLoc { get; private set; }
+        public string OtpInputPromptYubiTimeoutLoc { get; private set; }
     }
 }

--- a/src/XIVLauncher/Windows/ViewModel/SecurityKeySetupDialogViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/SecurityKeySetupDialogViewModel.cs
@@ -1,0 +1,34 @@
+﻿using CheapLoc;
+
+namespace XIVLauncher.Windows.ViewModel
+{
+    class SecurityKeySetupDialogViewModel
+    {
+        public SecurityKeySetupDialogViewModel()
+        {
+            SetupLoc();
+        }
+
+        private void SetupLoc()
+        {
+            KeySetupInputPromptInsertLoc = Loc.Localize("SetupInputPromptInsert", "Please insert your YubiKey now.");
+            KeySetupInputPromptYubiLoc = Loc.Localize("SetupInputPromptYubi", "Found a Yubikey.\nPlease enter your Authentication Key.");
+            CancelWithShortcutLoc = Loc.Localize("CancelWithShortcut", "_Cancel");
+            OkLoc = Loc.Localize("OK", "OK");
+            KeySetupOnClickHintLoc = Loc.Localize("SetupOnClickHint", "Don't know what this is?\n Check out the FAQ!");
+            KeySetupInputPromptBadLoc = Loc.Localize("SetupInputPromptBad", "Enter a valid Authentication Key.\nKey needs to be 32 characters long.");
+            KeySetupCheckBoxLoc = Loc.Localize("SetupCheckBox", "Require Touch?");
+            KeySetupTooltipLoc = Loc.Localize("SetupTooltip", "If checked, makes your YubiKey device require touch in order to authenticate.");
+
+        }
+        public string KeySetupInputPromptInsertLoc { get; private set; }
+        public string KeySetupInputPromptYubiLoc { get; private set; }
+        public string CancelWithShortcutLoc { get; private set; }
+        public string OkLoc { get; private set; }
+        public string KeySetupOnClickHintLoc { get; private set; }
+        public string KeySetupInputPromptBadLoc { get; private set; }
+        public string KeySetupCheckBoxLoc { get; private set; }
+        public string KeySetupTooltipLoc { get; private set; }
+
+    }
+}

--- a/src/XIVLauncher/Windows/ViewModel/SettingsControlViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/SettingsControlViewModel.cs
@@ -72,6 +72,10 @@ namespace XIVLauncher.Windows.ViewModel
             OtpServerTooltipLoc = Loc.Localize("OtpServerTooltip", "This will allow you to send your OTP code to XIVLauncher directly from your phone.\nClick \"Learn more\" to see how to set this up.");
             LearnMoreLoc = Loc.Localize("LearnMore", "Learn More");
             OtpLearnMoreTooltipLoc = Loc.Localize("OtpLearnMoreTooltipLoc", "Open a guide in your web browser.");
+            OtpYubiKeyCheckBoxLoc = Loc.Localize("OtpYubikeyCheckBox", "Enable YubiKey-based authentication");
+            OtpYubiKeyTooltipLoc = Loc.Localize("OtpYubikeyTooltip", "This will allow you to input your OTP code to XIVLauncher directly from touching your YubiKey.\nClick \"Learn more\" to see how to set this up.");
+            OtpSetupAuthLoc = Loc.Localize("OtpSetupAuth", "Setup Auth");
+            OtpSetupAuthTooltipLoc = Loc.Localize("OtpSetupAuthTooltip", "Sets up a physical YubiKey device.");
             AdditionalArgumentsLoc = Loc.Localize("AdditionalArguments", "Additional launch arguments");
             ChooseDpiAwarenessLoc = Loc.Localize("ChooseDpiAwareness", "Game DPI Awareness");
             DpiAwarenessAwareLoc = Loc.Localize("DpiAwarenessAware", "Aware");
@@ -179,6 +183,10 @@ namespace XIVLauncher.Windows.ViewModel
         public string OtpServerTooltipLoc { get; private set; }
         public string LearnMoreLoc { get; private set; }
         public string OtpLearnMoreTooltipLoc { get; private set; }
+        public string OtpYubiKeyCheckBoxLoc { get; private set; }
+        public string OtpYubiKeyTooltipLoc { get; private set; }
+        public string OtpSetupAuthLoc { get; private set; }
+        public string OtpSetupAuthTooltipLoc { get; private set; }
         public string AdditionalArgumentsLoc { get; private set; }
         public string ChooseDpiAwarenessLoc { get; private set; }
         public string ChooseDpiAwarenessHintLoc { get; private set; }

--- a/src/XIVLauncher/XIVLauncher.csproj
+++ b/src/XIVLauncher/XIVLauncher.csproj
@@ -86,6 +86,7 @@
     <PackageReference Include="squirrel.windows" Version="1.9.1" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.Text.Encodings.Web" Version="6.0.0" />
+    <PackageReference Include="Yubico.YubiKey" Version="1.8.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Adds ability to use a YubiKey security key to generate OTP codes and use them to login.

Please also consider this corresponding pull request on the faq repo: [#tbd](https://github.com/goatcorp/faq/pull/tbd)
- This guide outlines what a YubiKey is and how a user would setup their own to work with XIVLauncher.

---
### Additions:

SettingsControl
- Adds a new CheckBox that enables usage of YubiKey hardware [this requires OTP macros to be enabled]
- Added way for users to setup their YubiKey credentials in-app (See: SecurityKeySetupDialog)

YubiAuth
 - Finds and maintains reference to physical YubiKey device
 - Handles most methods that retrieve information from the security key and perform operations

OtpInputDialog
- If YubiKey setting is enabled, will attempt to login if device is plugged in or, if applicable, prompt the user to touch their device before authentication occurs
- Made so security key authentication doesn't block the main thread and normal login can occur if user desires

SecurityKeySetupDialog
- A dialog that allows users to enter their authentication key and create a credential on their security key
- User can also decide if they want to use touch prior to authentication

Directory.Build.targets
- Made to ensure the proper DLL is selected for the proper system architecture
  - This was incorrectly imported using the default Yubico.YubiKey implementation
 