### PR TITLE
Fix overzealous asset cleanup

### DIFF
--- a/src/XIVLauncher.Common/Dalamud/AssetManager.cs
+++ b/src/XIVLauncher.Common/Dalamud/AssetManager.cs
@@ -215,7 +215,7 @@ namespace XIVLauncher.Common.Dalamud
 
             foreach (var toDelete in baseDir.GetDirectories())
             {
-                if (toDelete != devDir && toDelete != currentDir)
+                if (toDelete.Name != devDir.Name && toDelete.Name != currentDir.Name)
                 {
                     toDelete.Delete(true);
                     Log.Verbose("[DASSET] Cleaned out {Path}", toDelete.FullName);


### PR DESCRIPTION
WinAPI is the worst and directory equality does not work how we expect. Quick hack via `Name` to check things.

Not as good as checking true filesystem equality, but fast and easy.