### PR TITLE
Try to avoid tempfile collisions in more places

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/Dxvk.cs
@@ -33,7 +33,7 @@ public static class Dxvk
     private static async Task DownloadDxvk(DirectoryInfo installDirectory)
     {
         using var client = new HttpClient();
-        var tempPath = Path.GetTempFileName();
+        var tempPath = PlatformHelpers.GetTempFileName();
 
         File.WriteAllBytes(tempPath, await client.GetByteArrayAsync(DXVK_DOWNLOAD));
         PlatformHelpers.Untar(tempPath, installDirectory.FullName);

--- a/src/XIVLauncher.Common/Dalamud/AssetManager.cs
+++ b/src/XIVLauncher.Common/Dalamud/AssetManager.cs
@@ -113,7 +113,7 @@ namespace XIVLauncher.Common.Dalamud
 
                 var packageUrl = info.PackageUrl;
 
-                var tempPath = Path.GetTempFileName();
+                var tempPath = PlatformHelpers.GetTempFileName();
 
                 if (File.Exists(tempPath))
                     File.Delete(tempPath);

--- a/src/XIVLauncher.Common/Util/PlatformHelpers.cs
+++ b/src/XIVLauncher.Common/Util/PlatformHelpers.cs
@@ -31,7 +31,7 @@ public static class PlatformHelpers
     public static string GetTempFileName()
     {
         // https://stackoverflow.com/a/50413126
-        return Path.Combine(Path.GetTempPath(), Guid.NewGuid().ToString());
+        return Path.Combine(Path.GetTempPath(), "xivlauncher_" + Guid.NewGuid());
     }
 
     public static void DeleteAndRecreateDirectory(DirectoryInfo dir)


### PR DESCRIPTION
Issues such as #1409 were reported by several users, and cleaning up their temp files seemed to solve the problem. We already have `PlatformHelpers.GetTempFileName()` (which is used in `DalamudUpdater.cs`) as a method for getting a more "collision resistant" temp file path, so I replaced other calls to `Path.GetTempFileName()` with that.

I also added an `xivlauncher_` prefix to our temp file names as I figure it's polite to let users know who is creating their temp files, and it could be useful for detecting bugs in the future (in case we are somehow responsible for this excessive temp file pollution, for example). If you'd prefer not to change this part, let me know and I'll remove it.

This is my first PR to FFXIVQuickLauncher so let me know if there's anything else I should do.