### PR TITLE
Enhance DLL checks for Windows

### DIFF
--- a/src/XIVLauncher.Common.Windows/WindowsDalamudCompatibilityCheck.cs
+++ b/src/XIVLauncher.Common.Windows/WindowsDalamudCompatibilityCheck.cs
@@ -80,7 +80,8 @@ public class WindowsDalamudCompatibilityCheck : IDalamudCompatibilityCheck
         {
             "ucrtbase_clr0400",
             "vcruntime140_clr0400",
-            "vcruntime140"
+            "vcruntime140",
+            "vcruntime140_1"
         };
 
         var passedRegistry = false;
@@ -106,6 +107,8 @@ public class WindowsDalamudCompatibilityCheck : IDalamudCompatibilityCheck
         {
             Log.Debug("Checking for DLL: " + path);
             passedDllChecks = passedDllChecks && CheckLibrary(path);
+            if (!CheckLibrary(path))
+                Log.Error("Cound not find " + path);
         }
 
         // Display our findings
@@ -116,7 +119,7 @@ public class WindowsDalamudCompatibilityCheck : IDalamudCompatibilityCheck
 
         if (!passedDllChecks)
         {
-            Log.Error("Missing DLL files required by Dalamud.");
+            Log.Error("Missing DLL files required by Dalamud. Please try installing vcredist bundle again.");
         }
 
         return (passedRegistry && passedDllChecks);


### PR DESCRIPTION
Add `vcruntime140_1` to list of DLLs we should ensure the user has.

Re-add logging for missing DLLs to make support team's life easier when recommending what's missing.
