### PR TITLE
Modify/remove auto-launch addons by index instead of name

### DIFF
--- a/src/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -203,16 +203,15 @@ namespace XIVLauncher.Windows
 
             if (entry.Addon is GenericAddon genericAddon)
             {
+                var selectedIndex = AddonListView.SelectedIndex;
                 var addonSetup = new GenericAddonSetupWindow(genericAddon);
                 addonSetup.ShowDialog();
 
                 if (addonSetup.Result != null)
                 {
-                    App.Settings.AddonList = App.Settings.AddonList.Where(x => x.Addon is GenericAddon thisGenericAddon && thisGenericAddon.Path != genericAddon.Path).ToList();
-
                     var addonList = App.Settings.AddonList;
-
-                    addonList.Add(new AddonEntry
+                    addonList.RemoveAt(selectedIndex);
+                    addonList.Insert(selectedIndex, new AddonEntry
                     {
                         IsEnabled = entry.IsEnabled,
                         Addon = addonSetup.Result
@@ -232,9 +231,12 @@ namespace XIVLauncher.Windows
 
         private void RemoveAddonEntry_OnClick(object sender, RoutedEventArgs e)
         {
-            if (AddonListView.SelectedItem is AddonEntry entry && entry.Addon is GenericAddon genericAddon)
+            if (AddonListView.SelectedItem is AddonEntry)
             {
-                App.Settings.AddonList = App.Settings.AddonList.Where(x => x.Addon is GenericAddon thisGenericAddon && thisGenericAddon.Path != genericAddon.Path).ToList();
+                var addonList = App.Settings.AddonList;
+                addonList.RemoveAt(this.AddonListView.SelectedIndex);
+
+                App.Settings.AddonList = addonList;
 
                 AddonListView.ItemsSource = App.Settings.AddonList;
             }


### PR DESCRIPTION
Fixes #1434 by using SelectedIndex to modify/remove auto-launch addon entries by index, rather than modifying all addons with the same name.