### PR TITLE
Fix some boot hash targets not existing anymore

### DIFF
--- a/src/XIVLauncher.Common/Game/Launcher.cs
+++ b/src/XIVLauncher.Common/Game/Launcher.cs
@@ -360,14 +360,12 @@ public class Launcher
 
         for (var i = 0; i < FilesToHash.Length; i++)
         {
-            result +=
-                $"{FilesToHash[i]}/{GetFileHash(Path.Combine(gamePath.FullName, "boot", FilesToHash[i]))}";
-
-            if (i != FilesToHash.Length - 1)
-                result += ",";
+            var path = Path.Combine(gamePath.FullName, "boot", FilesToHash[i]);
+            if (!File.Exists(path)) continue;
+            result += $"{FilesToHash[i]}/{GetFileHash(path)},";
         }
-
-        return result;
+        
+        return result.TrimEnd(',');
     }
 
     public async Task<PatchListEntry[]> CheckBootVersion(DirectoryInfo gamePath)

--- a/src/XIVLauncher.Common/Game/Launcher.cs
+++ b/src/XIVLauncher.Common/Game/Launcher.cs
@@ -81,9 +81,7 @@ public class Launcher
     {
         "ffxivboot.exe",
         "ffxivboot64.exe",
-        "ffxivlauncher.exe",
         "ffxivlauncher64.exe",
-        "ffxivupdater.exe",
         "ffxivupdater64.exe"
     };
 

--- a/src/XIVLauncher.Common/Game/Launcher.cs
+++ b/src/XIVLauncher.Common/Game/Launcher.cs
@@ -360,12 +360,14 @@ public class Launcher
 
         for (var i = 0; i < FilesToHash.Length; i++)
         {
-            var path = Path.Combine(gamePath.FullName, "boot", FilesToHash[i]);
-            if (!File.Exists(path)) continue;
-            result += $"{FilesToHash[i]}/{GetFileHash(path)},";
+            result +=
+                $"{FilesToHash[i]}/{GetFileHash(Path.Combine(gamePath.FullName, "boot", FilesToHash[i]))}";
+
+            if (i != FilesToHash.Length - 1)
+                result += ",";
         }
-        
-        return result.TrimEnd(',');
+
+        return result;
     }
 
     public async Task<PatchListEntry[]> CheckBootVersion(DirectoryInfo gamePath)


### PR DESCRIPTION
They deleted some of the files we hash for boot so I'm just skipping the ones that don't exist. Also because the last entry isn't guaranteed to exist I moved to TrimEnd for the comma.