### PR TITLE
Add download eta to project

### DIFF
--- a/src/XIVLauncher.Common/Util/ApiHelpers.cs
+++ b/src/XIVLauncher.Common/Util/ApiHelpers.cs
@@ -29,7 +29,7 @@ public static class ApiHelpers
     public static string GetTimeLeft(TimeSpan span, string[] locs)
     {
         if (span.TotalSeconds < 1)
-            return "0s";
+            return "";
 
         var seconds = (long)span.TotalSeconds;
         var minutes = seconds / 60;

--- a/src/XIVLauncher.Common/Util/ApiHelpers.cs
+++ b/src/XIVLauncher.Common/Util/ApiHelpers.cs
@@ -26,6 +26,24 @@ public static class ApiHelpers
         return $"{(Math.Sign(byteCount) * num):#0.0}{suf[place]}";
     }
 
+    public static string GetTimeLeft(TimeSpan span, string[] locs)
+    {
+        if (span.TotalSeconds < 1)
+            return "0s";
+
+        var seconds = (long)span.TotalSeconds;
+        var minutes = seconds / 60;
+        var hours = minutes / 60;
+        var days = hours / 24;
+
+        if (days > 0)
+            return string.Format(locs[0], days, hours % 24, minutes % 60, seconds % 60);
+        if (hours > 0)
+            return string.Format(locs[1], hours, minutes % 60, seconds % 60);
+
+        return minutes > 0 ? string.Format(locs[2], minutes, seconds % 60) : string.Format(locs[3], seconds % 60);
+    }
+
     public static string GenerateAcceptLanguage(int asdf = 0)
     {
         var codes = new string[] { "de-DE", "en-US", "ja" };

--- a/src/XIVLauncher/Windows/PatchDownloadDialog.xaml
+++ b/src/XIVLauncher/Windows/PatchDownloadDialog.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="XIVLauncher.Windows.PatchDownloadDialog"
+<Window x:Class="XIVLauncher.Windows.PatchDownloadDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -13,7 +13,7 @@
         FontFamily="pack://application:,,,/MaterialDesignThemes.Wpf;component/Resources/Roboto/#Roboto"
         AllowsTransparency="True"
         Background="Transparent"
-        WindowStyle="None" Height="225" Width="340"
+        WindowStyle="None" Height="240" Width="340"
         d:DataContext="{d:DesignInstance viewModel:PatchDownloadDialogViewModel}" Closing="PatchDownloadDialog_OnClosing">
     <Grid Margin="0,0,0,0">
         <materialDesign:Card Background="{DynamicResource MaterialDesignPaper}" Height="Auto" Margin="0,0,10,0">
@@ -31,7 +31,8 @@
                 <TextBlock x:Name="InstallingText" Foreground="{DynamicResource MaterialDesignBody}" HorizontalAlignment="Center" Text="{Binding PatchInstallingLoc}"></TextBlock>
                 <ProgressBar IsIndeterminate="True" Margin="0,0,0,11" />
 
-                <TextBlock x:Name="BytesLeftText" Foreground="DarkGray" Margin="0,8,0,12" TextAlignment="Center" Text="{Binding PatchPreparingLoc}"/>
+                <TextBlock x:Name="BytesLeftText" Foreground="DarkGray" Margin="0,8,0,0" TextAlignment="Center" Text="{Binding PatchPreparingLoc}"/>
+                <TextBlock x:Name="TimeLeftText" Foreground="DarkGray" Margin="0,0,0,12" TextAlignment="Center" Text="{Binding PatchPreparingLoc}"/>
             </StackPanel>
         </materialDesign:Card>
     </Grid>

--- a/src/XIVLauncher/Windows/PatchDownloadDialog.xaml.cs
+++ b/src/XIVLauncher/Windows/PatchDownloadDialog.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Linq;
 using System.Timers;
@@ -99,7 +99,9 @@ namespace XIVLauncher.Windows
 
         public void SetLeft(long left, double rate)
         {
+            TimeSpan eta = rate == 0 ? TimeSpan.Zero : TimeSpan.FromSeconds(left / rate);
             BytesLeftText.Text = string.Format(ViewModel.PatchEtaLoc, ApiHelpers.BytesToString(left), ApiHelpers.BytesToString(rate));
+            TimeLeftText.Text = ApiHelpers.GetTimeLeft(eta, ViewModel.PatchEtaTimeLoc);
         }
 
         public void SetPatchProgress(int index, string patchName, double pct, bool indeterminate)

--- a/src/XIVLauncher/Windows/ViewModel/PatchDownloadDialogViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/PatchDownloadDialogViewModel.cs
@@ -1,4 +1,4 @@
-﻿using CheapLoc;
+using CheapLoc;
 
 namespace XIVLauncher.Windows.ViewModel
 {
@@ -19,6 +19,13 @@ namespace XIVLauncher.Windows.ViewModel
             PatchInstallingFormattedLoc = Loc.Localize("PatchInstallingFormatted", "Installing #{0}...");
             PatchInstallingIdleLoc = Loc.Localize("PatchInstallingIdle", "Waiting for download...");
             PatchEtaLoc = Loc.Localize("PatchEta", "{0} left to download at {1}/s.");
+            PatchEtaTimeLoc = new[]
+            {
+                Loc.Localize("PatchEtaTimeDays", "ETA: {0}d {1}h {2}m {3}s"),
+                Loc.Localize("PatchEtaTimeHours", "ETA: {0}h {1}m {2}s"),
+                Loc.Localize("PatchEtaTimeMinutes", "ETA: {0}m {1}s"),
+                Loc.Localize("PatchEtaTimeSeconds", "ETA: {0}s"),
+            };
         }
 
         public string PatchPreparingLoc { get; private set; }
@@ -29,5 +36,6 @@ namespace XIVLauncher.Windows.ViewModel
         public string PatchInstallingFormattedLoc { get; private set; }
         public string PatchInstallingIdleLoc { get; private set; }
         public string PatchEtaLoc { get; private set; }
+        public string[] PatchEtaTimeLoc { get; private set; }
     }
 }

--- a/src/XIVLauncher/Windows/ViewModel/PatchDownloadDialogViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/PatchDownloadDialogViewModel.cs
@@ -21,10 +21,10 @@ namespace XIVLauncher.Windows.ViewModel
             PatchEtaLoc = Loc.Localize("PatchEta", "{0} left to download at {1}/s.");
             PatchEtaTimeLoc = new[]
             {
-                Loc.Localize("PatchEtaTimeDays", "ETA: {0}d {1}h {2}m {3}s"),
-                Loc.Localize("PatchEtaTimeHours", "ETA: {0}h {1}m {2}s"),
-                Loc.Localize("PatchEtaTimeMinutes", "ETA: {0}m {1}s"),
-                Loc.Localize("PatchEtaTimeSeconds", "ETA: {0}s"),
+                Loc.Localize("PatchEtaTimeDays", "Download ETA: {0}d {1}h {2}m {3}s"),
+                Loc.Localize("PatchEtaTimeHours", "Download ETA: {0}h {1}m {2}s"),
+                Loc.Localize("PatchEtaTimeMinutes", "Download ETA: {0}m {1}s"),
+                Loc.Localize("PatchEtaTimeSeconds", "Download ETA: {0}s"),
             };
         }
 


### PR DESCRIPTION
Closes #1448 

Just a simple ETA printout for the download progress might come in use with 7.0 being a large download

![img](https://screenshots.wildwolf.dev/dd62c3f955.png)

This adds 4 more translation strings as this was the easiest way to handle it.