### PR TITLE
Bump fallback ZIP url

### DIFF
--- a/src/XIVLauncher.Common.Unix/Compatibility/GameFixes/Implementations/MacVideoFix.cs
+++ b/src/XIVLauncher.Common.Unix/Compatibility/GameFixes/Implementations/MacVideoFix.cs
@@ -15,7 +15,7 @@ public class MacVideoFix : GameFix
     private static async Task<string> GetLatestMacZipUrl()
     {
         const string SPARKLE_FEED_URL = "https://mac-dl.ffxiv.com/cw/finalfantasy-mac.xml";
-        const string FALLBACK_URL = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-1.1.2.zip";
+        const string FALLBACK_URL = "https://mac-dl.ffxiv.com/cw/finalfantasyxiv-1.1.4.zip";
 
         try
         {


### PR DESCRIPTION
1.1.2 is dead, long live 1.1.4