### PR TITLE
Refresh vcruntime check

### DIFF
--- a/src/XIVLauncher.Common.Windows/WindowsDalamudCompatibilityCheck.cs
+++ b/src/XIVLauncher.Common.Windows/WindowsDalamudCompatibilityCheck.cs
@@ -64,6 +64,13 @@ public class WindowsDalamudCompatibilityCheck : IDalamudCompatibilityCheck
             @"SOFTWARE\Microsoft\DevDiv\VC\Servicing\14.0\RuntimeMinimum",
             @"SOFTWARE\Microsoft\VisualStudio\14.0\VC\Runtimes\X64",
             @"SOFTWARE\Classes\Installer\Dependencies\Microsoft.VS.VC_RuntimeMinimumVSU_amd64,v14",
+            @"SOFTWARE\Classes\Installer\Dependencies\VC,redist.x64,amd64,14.38,bundle",
+            @"SOFTWARE\Classes\Installer\Dependencies\VC,redist.x64,amd64,14.37,bundle",
+            @"SOFTWARE\Classes\Installer\Dependencies\VC,redist.x64,amd64,14.36,bundle",
+            @"SOFTWARE\Classes\Installer\Dependencies\VC,redist.x64,amd64,14.35,bundle",
+            @"SOFTWARE\Classes\Installer\Dependencies\VC,redist.x64,amd64,14.34,bundle",
+            @"SOFTWARE\Classes\Installer\Dependencies\VC,redist.x64,amd64,14.33,bundle",
+            @"SOFTWARE\Classes\Installer\Dependencies\VC,redist.x64,amd64,14.32,bundle",
             @"SOFTWARE\Classes\Installer\Dependencies\VC,redist.x64,amd64,14.31,bundle",
             @"SOFTWARE\Classes\Installer\Dependencies\VC,redist.x64,amd64,14.30,bundle",
             @"SOFTWARE\Classes\Installer\Dependencies\VC,redist.x64,amd64,14.29,bundle",
@@ -94,7 +101,8 @@ public class WindowsDalamudCompatibilityCheck : IDalamudCompatibilityCheck
 
             var vcVersioncheck = vcregcheck.GetValue("Version") ?? "";
 
-            if (((string)vcVersioncheck).StartsWith("14", StringComparison.Ordinal))
+            if (((string)vcVersioncheck).StartsWith("14", StringComparison.Ordinal) 
+                || ((string)vcVersioncheck).StartsWith("v14", StringComparison.Ordinal))
             {
                 passedRegistry = true;
                 Log.Debug("Passed Registry Check with: " + path);


### PR DESCRIPTION
Some registry entries start with `v14` instead of `14` and we weren't matching those.

Also add additional fallbacks up to the latest minor version.
