### PR TITLE
[CI/CD] Update action-gh-release

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -54,7 +54,7 @@ jobs:
           rm ".\Releases\$($delta_file.name)"
           rm ".\Releases\$($full_file.name)"
       - name: Create Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@a74c6b72af54cfa997e81df42d94703d6313a2d0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -54,11 +54,11 @@ jobs:
           rm ".\Releases\$($delta_file.name)"
           rm ".\Releases\$($full_file.name)"
       - name: Create Release
-        uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
+        uses: softprops/action-gh-release@v2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          files: src\Releases\**
+          files: ./src/Releases/**
           name: Release ${{ steps.build-squirrel.outputs.version }}
           body_path:  RELEASE.md
           prerelease: true


### PR DESCRIPTION
I think github deprecated some of the APIs so the action at that commit [failed as 404 on our end](https://github.com/ottercorp/FFXIVQuickLauncher/actions/runs/9557942271/job/26345998534):
<img width="835" alt="image" src="https://github.com/goatcorp/FFXIVQuickLauncher/assets/9719003/5550193f-b81a-42bf-9827-03fed9eb7ecb">

Update it to a74c6b72af54cfa997e81df42d94703d6313a2d0 (action-gh-release@v2.0.6) to be compatible with the latest github release API.

Also chages the `\` in path to `/` as said in [README of action-gh-release](https://github.com/softprops/action-gh-release?tab=readme-ov-file#%EF%B8%8F-uploading-release-assets).