### PR TITLE
Removed openssl options for linux. No longer needed.

### DIFF
--- a/src/XIVLauncher.Common/Game/Launcher.cs
+++ b/src/XIVLauncher.Common/Game/Launcher.cs
@@ -46,23 +46,10 @@ public class Launcher
 
         ServicePointManager.Expect100Continue = false;
 
-#if NET6_0_OR_GREATER && !WIN32
-        var sslOptions = new SslClientAuthenticationOptions()
-        {
-            CipherSuitesPolicy = new CipherSuitesPolicy(new[] { TlsCipherSuite.TLS_DHE_RSA_WITH_AES_256_GCM_SHA384 })
-        };
-
-        var handler = new SocketsHttpHandler
-        {
-            UseCookies = false,
-            SslOptions = sslOptions,
-        };
-#else
         var handler = new HttpClientHandler
         {
             UseCookies = false,
         };
-#endif
 
         this.client = new HttpClient(handler);
     }


### PR DESCRIPTION
We previously had a workaround for Square's crappy SSL implementation. It appears they have modernized, and we can get rid of it for Linux, now.