### PR TITLE
Limit http header size on repairs

### DIFF
--- a/src/XIVLauncher.Common/Patching/IndexedZiPatch/IndexedZiPatchInstaller.cs
+++ b/src/XIVLauncher.Common/Patching/IndexedZiPatch/IndexedZiPatchInstaller.cs
@@ -534,12 +534,11 @@ public class IndexedZiPatchInstaller : IDisposable
             }
 
             using HttpRequestMessage req = new(HttpMethod.Get, SourceUrl);
-            req.Headers.Range = new()
-            {
-                Unit = "bytes"
-            };
-            foreach (var (rangeFrom, rangeToExclusive) in offsets)
+            req.Headers.Range = new() { Unit = "bytes" };
+            foreach (var (rangeFrom, rangeToExclusive) in offsets.Take(400))
                 req.Headers.Range.Ranges.Add(new(rangeFrom, rangeToExclusive + 1));
+            // "1000000000-1000000000,": 22 bytes; 22x400=8800 bytes in HTTP header should be fine?
+
             if (this.sid != null)
                 req.Headers.Add("X-Patch-Unique-Id", this.sid);
             req.Headers.Add("User-Agent", Constants.PatcherUserAgent);


### PR DESCRIPTION
Previously, number of ranges requested in a single requests was unbounded, which could have resulted in server response indicating that the header is too large. This commit changes that by limiting to 400 ranges per request.