### PR TITLE
Fix xlcore oathloginexception

### DIFF
--- a/src/XIVLauncher.Common/Game/Exceptions/OauthLoginException.cs
+++ b/src/XIVLauncher.Common/Game/Exceptions/OauthLoginException.cs
@@ -28,12 +28,12 @@ public class OauthLoginException : Exception
     {
         var matches = errorMessageRegex.Matches(document);
 
-        // Handle xlcore error messages
-        if (xlcoreMessages.Contains(document))
-            return document;
-
         if (matches.Count is 0 or > 1)
         {
+            // Handle xlcore error messages
+            if (xlcoreMessages.Contains(document))
+                return document;
+
             Log.Error("Could not get login error\n{Doc}", document);
             return null;
         }

--- a/src/XIVLauncher.Common/Game/Exceptions/OauthLoginException.cs
+++ b/src/XIVLauncher.Common/Game/Exceptions/OauthLoginException.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Text.RegularExpressions;
+using System.Linq;
 using Serilog;
 
 namespace XIVLauncher.Common.Game.Exceptions;
@@ -9,6 +10,11 @@ public class OauthLoginException : Exception
 {
     private static Regex errorMessageRegex =
         new(@"window.external.user\(""login=auth,ng,err,(?<errorMessage>.*)\""\);", RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    // XL.Core error messages used in MainPage.cs. Needs to match for this to work.
+    private static string[] xlcoreMessages = 
+        new string[] { "No service account or subscription", "Need to accept terms of use", 
+                       "Boot conflict, need reinstall", "Repair login state not NeedsPatchGame" };
 
     public string? OauthErrorMessage { get; private set; }
 
@@ -21,6 +27,10 @@ public class OauthLoginException : Exception
     private static string? GetErrorMessage(string document)
     {
         var matches = errorMessageRegex.Matches(document);
+
+        // Handle xlcore error messages
+        if (xlcoreMessages.Contains(document))
+            return document;
 
         if (matches.Count is 0 or > 1)
         {


### PR DESCRIPTION
Adds logic to OauthLoginException to deal with XL.Core error messages. There may be a way to do it by modifying the regex, but this works fine in my testing. I created a temporary env variable to set the login state manually. The errors will now show up with the error text instead of displaying "Unknown error".