### PR TITLE
Fix Steam Auto-Launch, Simplify OTP Handling Using Configuration and Not Server / APK

### DIFF
--- a/src/XIVLauncher.Common.Tests/XIVLauncher.Common.Tests.csproj
+++ b/src/XIVLauncher.Common.Tests/XIVLauncher.Common.Tests.csproj
@@ -12,6 +12,7 @@
         <PackageReference Include="MSTest.TestAdapter" Version="2.2.7" />
         <PackageReference Include="MSTest.TestFramework" Version="2.2.7" />
         <PackageReference Include="coverlet.collector" Version="3.1.0" />
+        <PackageReference Include="Otp.NET" Version="1.4.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/XIVLauncher.Common.Unix/XIVLauncher.Common.Unix.csproj
+++ b/src/XIVLauncher.Common.Unix/XIVLauncher.Common.Unix.csproj
@@ -45,5 +45,6 @@
     <ItemGroup>
         <!-- Custom steamworks, based on the chippy branch of Facepunch.Steamworks -->
         <PackageReference Include="goaaats.Steamworks" Version="2.3.4" />
+        <PackageReference Include="Otp.NET" Version="1.4.0" />
     </ItemGroup>
 </Project>

--- a/src/XIVLauncher.Common.Windows/WindowsSteam.cs
+++ b/src/XIVLauncher.Common.Windows/WindowsSteam.cs
@@ -13,7 +13,8 @@ namespace XIVLauncher.Common.Windows
 {
     public class WindowsSteam : ISteam
     {
-        private const int MAX_INIT_TRIES_AFTER_START = 15;
+        //MATUK MOD BUG FIX
+        private const int MAX_INIT_TRIES_AFTER_START = 60;
 
         public Task? AsyncStartTask { get; private set; }
 

--- a/src/XIVLauncher.Common.Windows/XIVLauncher.Common.Windows.csproj
+++ b/src/XIVLauncher.Common.Windows/XIVLauncher.Common.Windows.csproj
@@ -41,6 +41,7 @@
 
         <!-- Custom steamworks, based on the chippy branch of Facepunch.Steamworks -->
         <PackageReference Include="goaaats.Steamworks" Version="2.3.4" />
+        <PackageReference Include="Otp.NET" Version="1.4.0" />
         <PackageReference Include="PInvoke.Kernel32" Version="0.7.124" />
     </ItemGroup>
 </Project>

--- a/src/XIVLauncher.Common/XIVLauncher.Common.csproj
+++ b/src/XIVLauncher.Common/XIVLauncher.Common.csproj
@@ -44,6 +44,7 @@
         <PackageReference Include="CommandLineParser" Version="2.9.1" />
         <PackageReference Include="Downloader" Version="2.2.8" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+        <PackageReference Include="Otp.NET" Version="1.4.0" />
         <PackageReference Include="Serilog" Version="2.12.0" />
         <PackageReference Include="Serilog.Enrichers.Sensitive" Version="1.7.2" />
         <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />

--- a/src/XIVLauncher.PatchInstaller/XIVLauncher.PatchInstaller.csproj
+++ b/src/XIVLauncher.PatchInstaller/XIVLauncher.PatchInstaller.csproj
@@ -30,6 +30,7 @@
 
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="Otp.NET" Version="1.4.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="3.1.1" />

--- a/src/XIVLauncher/Settings/ILauncherSettingsV3.cs
+++ b/src/XIVLauncher/Settings/ILauncherSettingsV3.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.IO;
 using XIVLauncher.Common;
 using XIVLauncher.Common.Addon;
@@ -16,6 +16,10 @@ namespace XIVLauncher.Settings
         bool AutologinEnabled { get; set; }
         List<AddonEntry> AddonList { get; set; }
         bool UniqueIdCacheEnabled { get; set; }
+
+        //MATUK MOD
+        string OTPCodeConfig { get; set; }
+
         string AdditionalLaunchArgs { get; set; }
         bool InGameAddonEnabled { get; set; }
         DalamudLoadMethod? InGameAddonLoadMethod { get; set; }

--- a/src/XIVLauncher/Windows/SettingsControl.xaml
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml
@@ -1,4 +1,4 @@
-﻿<UserControl x:Class="XIVLauncher.Windows.SettingsControl"
+<UserControl x:Class="XIVLauncher.Windows.SettingsControl"
              xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -17,7 +17,7 @@
              d:DataContext="{d:DesignInstance viewModel:SettingsControlViewModel}">
     <Grid>
         <dragablz:TabablzControl IsEnabled="True" FixedHeaderCount="7" x:Name="SetupTabControl"
-                                 Style="{StaticResource MaterialDesignTabablzControlStyle}">
+                                 Style="{StaticResource MaterialDesignTabablzControlStyle}" SelectionChanged="SetupTabControl_SelectionChanged">
             <TabItem Header="{Binding SettingsGameLoc}">
                 <StackPanel Margin="10,10,0,0">
                     <TextBlock HorizontalAlignment="Left" VerticalAlignment="Top"
@@ -37,7 +37,13 @@
                     <TextBlock HorizontalAlignment="Left" VerticalAlignment="Top"
                                Foreground="Red" Text="{Binding GamePathSafeguardLoc}" x:Name="GamePathSafeguardText" Visibility="Collapsed"/>
 
-                    <StackPanel Orientation="Horizontal" Margin="0,15,0,0">
+                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                        <TextBox Width="200" VerticalAlignment="Center"
+                            HorizontalAlignment="Left" Foreground="{DynamicResource MaterialDesignBody}"
+                            Margin="0,0,0,0" x:Name="OTPCodeConfig" materialDesign:HintAssist.Hint="Type your OTP code here" materialDesign:HintAssist.IsFloating="True"/>
+                    </StackPanel>
+
+                    <StackPanel Orientation="Horizontal" Margin="0,15,0,0" Visibility="Collapsed">
                         <CheckBox Foreground="{DynamicResource MaterialDesignBody}"
                                   x:Name="OtpServerCheckBox" Content="{Binding OtpServerCheckBoxLoc}" ToolTip="{Binding OtpServerTooltipLoc}"/>
                         <Button Style="{DynamicResource MaterialDesignFlatButton}"

--- a/src/XIVLauncher/Windows/SettingsControl.xaml.cs
+++ b/src/XIVLauncher/Windows/SettingsControl.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
@@ -77,6 +77,10 @@ namespace XIVLauncher.Windows
 
             OtpServerCheckBox.IsChecked = App.Settings.OtpServerEnabled;
 
+            //MATUK MOD
+            OTPCodeConfig.Text = App.Settings.OTPCodeConfig;
+
+
             LaunchArgsTextBox.Text = App.Settings.AdditionalLaunchArgs;
 
             DpiAwarenessComboBox.SelectedIndex = (int) App.Settings.DpiAwareness.GetValueOrDefault(DpiAwareness.Unaware);
@@ -123,6 +127,10 @@ namespace XIVLauncher.Windows
                 App.Settings.InGameAddonLoadMethod = DalamudLoadMethod.DllInject;
             else
                 App.Settings.InGameAddonLoadMethod = DalamudLoadMethod.EntryPoint;
+
+            //MATUK
+            App.Settings.OTPCodeConfig = OTPCodeConfig.Text;
+
 
             App.Settings.OtpServerEnabled = OtpServerCheckBox.IsChecked == true;
 
@@ -432,6 +440,11 @@ namespace XIVLauncher.Windows
         {
             var asw = new AdvancedSettingsWindow();
             asw.ShowDialog();
+        }
+
+        private void SetupTabControl_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+
         }
     }
 }

--- a/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
@@ -13,6 +13,7 @@ using System.Windows.Input;
 using System.Windows.Media;
 using System.Windows.Threading;
 using CheapLoc;
+using OtpNet;
 using Serilog;
 using XIVLauncher.Accounts;
 using XIVLauncher.Common;
@@ -273,8 +274,13 @@ namespace XIVLauncher.Windows.ViewModel
 
             var hasValidCache = App.UniqueIdCache.HasValidCache(username) && App.Settings.UniqueIdCacheEnabled;
 
-            var otp = string.Empty;
+            //MATUK MOD
+            string secret = App.Settings.OTPCodeConfig;
+            var secretKey = Base32Encoding.ToBytes(secret);
+            var totp = new Totp(secretKey);
+            var otp = totp.ComputeTotp();
 
+            /*var otp = string.Empty;
             if (isOtp && (!hasValidCache || action == AfterLoginAction.Repair))
             {
                 otp = OtpInputDialog.AskForOtp((otpDialog, result) =>
@@ -285,7 +291,7 @@ namespace XIVLauncher.Windows.ViewModel
                                                                    "This OTP has been already used.\nIt may take up to 30 seconds for a new one."));
                     }
                 }, _window);
-            }
+            }*/
 
             if (otp == null)
                 return;

--- a/src/XIVLauncher/XIVLauncher.csproj
+++ b/src/XIVLauncher/XIVLauncher.csproj
@@ -79,6 +79,7 @@
     <PackageReference Include="MaterialDesignThemes" Version="4.3.0" />
     <PackageReference Include="Microsoft.CSharp" Version="4.5.0" />
     <PackageReference Include="Microsoft.WindowsAPICodePack-Shell" Version="1.1.0" />
+    <PackageReference Include="Otp.NET" Version="1.4.0" />
     <PackageReference Include="Serilog" Version="2.12.0" />
     <PackageReference Include="Serilog.Sinks.Async" Version="1.5.0" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="1.0.1" />


### PR DESCRIPTION
Made some improvements to Steam's functionality:

- Fixed the issue with Steam not opening automatically.
- Added a configuration option to save your OTP code directly in the settings, making auto-login easier—no need for extra servers or APKs.

Enjoy the smoother experience! 😊