### PR TITLE
Copy xlcore's method for frontier fallback

### DIFF
--- a/src/XIVLauncher.Common/Constants.cs
+++ b/src/XIVLauncher.Common/Constants.cs
@@ -10,6 +10,8 @@ namespace XIVLauncher.Common
         public const uint STEAM_APP_ID = 39210;
         public const uint STEAM_FT_APP_ID = 312060;
 
+        public const string LAUNCHER_CONFIG_URL = "https://kamori.goats.dev/Launcher/GetLauncherClientConfig";
+        public const string FRONTIER_FALLBACK = "https://launcher.finalfantasyxiv.com/v650/index.html?rc_lang={0}&time={1}";
         public static string PatcherUserAgent => GetPatcherUserAgent(PlatformHelpers.GetPlatform());
 
         private static string GetPatcherUserAgent(Platform platform)

--- a/src/XIVLauncher.Common/XIVLauncher.Common.csproj
+++ b/src/XIVLauncher.Common/XIVLauncher.Common.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <Product>XIVLauncher.Common</Product>
         <AssemblyTitle>XIVLauncher.Common</AssemblyTitle>
@@ -52,6 +52,7 @@
         <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
         <PackageReference Include="SharedMemory" Version="2.3.2" />
         <PackageReference Include="System.Memory" Version="4.5.4" />
+        <PackageReference Include="System.Net.Http.Json" Version="6.0.0" />
         <PackageReference Include="System.Security.Principal.Windows" Version="5.0.0" />
         <PackageReference Include="System.Text.Json" Version="6.0.6" />
     </ItemGroup>

--- a/src/XIVLauncher.PatchInstaller/Commands/IndexUpdateCommand.cs
+++ b/src/XIVLauncher.PatchInstaller/Commands/IndexUpdateCommand.cs
@@ -78,7 +78,7 @@ public class IndexUpdateCommand
 
     private async Task<int> Handle(CancellationToken cancellationToken)
     {
-        var la = new Launcher((ISteam?)null, new CommonUniqueIdCache(null), this.settings, "https://launcher.finalfantasyxiv.com/v650/index.html?rc_lang={0}&time={1}");
+        var la = new Launcher((ISteam?)null, new CommonUniqueIdCache(null), this.settings, XIVLauncher.Common.Util.ApiHelpers.LauncherClientConfig.GetAsync().GetAwaiter().GetResult().frontierUrl);
 
         var bootPatchListFile = new FileInfo(Path.Combine(this.settings.GamePath.FullName, "bootlist.json"));
 

--- a/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
+++ b/src/XIVLauncher/Windows/ViewModel/MainWindowViewModel.cs
@@ -78,7 +78,7 @@ namespace XIVLauncher.Windows.ViewModel
             var frontierUrl = Updates.UpdateLease?.FrontierUrl;
 #if DEBUG || RELEASENOUPDATE
             // FALLBACK
-            frontierUrl ??= "https://launcher.finalfantasyxiv.com/v650/index.html?rc_lang={0}&time={1}";
+            frontierUrl ??= XIVLauncher.Common.Util.ApiHelpers.LauncherClientConfig.GetAsync().GetAwaiter().GetResult().frontierUrl;
 #endif
 
             Launcher = App.GlobalSteamTicket == null


### PR DESCRIPTION
Turns out things explode if you run the launcher with  XL_NOAUTOUPDATE because the frontier fallback didn't work / was old.

While I could have just changed a couple 650s to 710s, I didn't really like that patchinstaller also relies on a hardcoded entry.

So I'm copying the method that xlcore uses to try to fetch from kamori first. And then use a gross fallback, but in a place where we'd only have to change it once.

I'm certain there's a better way to do this, but I'm tired and this was the fastest/easiest I could think of.
