### PR TITLE
feat: set AppUserModelId for the launcher

### DIFF
--- a/src/XIVLauncher/App.xaml.cs
+++ b/src/XIVLauncher/App.xaml.cs
@@ -23,6 +23,7 @@ using XIVLauncher.PlatformAbstractions;
 using XIVLauncher.Settings;
 using XIVLauncher.Settings.Parsers;
 using XIVLauncher.Support;
+using XIVLauncher.Utilities;
 using XIVLauncher.Windows;
 using XIVLauncher.Xaml;
 
@@ -297,6 +298,9 @@ namespace XIVLauncher
             {
                 // ignored
             }
+
+            // needs to be set early, and needs to be the same as what Squirrel sets for sanity's sake.
+            NativeFunctions.SetCurrentProcessExplicitAppUserModelID("com.squirrel.XIVLauncher.XIVLauncher");
 
             try
             {

--- a/src/XIVLauncher/Utilities/NativeFunctions.cs
+++ b/src/XIVLauncher/Utilities/NativeFunctions.cs
@@ -1,0 +1,9 @@
+using System.Runtime.InteropServices;
+
+namespace XIVLauncher.Utilities;
+
+internal class NativeFunctions
+{
+    [DllImport("shell32.dll", SetLastError = true)]
+    internal static extern void SetCurrentProcessExplicitAppUserModelID([MarshalAs(UnmanagedType.LPWStr)] string appId);
+}


### PR DESCRIPTION
This PR aims to clean up a Squirrelism with taskbar icons.

Currently, only the Squirrel launcher can be pinned to the taskbar, leading to a duplicate entry for XL itself. This combines the two into a single entry.