### PR TITLE
use fallback links for news items without one

### DIFF
--- a/src/XIVLauncher.Common/ClientLanguage.cs
+++ b/src/XIVLauncher.Common/ClientLanguage.cs
@@ -35,5 +35,29 @@ namespace XIVLauncher.Common
                     return "en-gb";
             }
         }
+
+        public static string GetLangCodeLodestone(this ClientLanguage language, bool forceNa = false)
+        {
+            switch (language)
+            {
+                case ClientLanguage.Japanese:
+                    return "jp";
+
+                case ClientLanguage.English when GameHelpers.IsRegionNorthAmerica() || forceNa:
+                    return "na";
+
+                case ClientLanguage.English:
+                    return "eu";
+
+                case ClientLanguage.German:
+                    return "de";
+
+                case ClientLanguage.French:
+                    return "fr";
+
+                default:
+                    return "eu";
+            }
+        }
     }
 }

--- a/src/XIVLauncher.Common/Game/Headlines.cs
+++ b/src/XIVLauncher.Common/Game/Headlines.cs
@@ -70,7 +70,22 @@ namespace XIVLauncher.Common.Game
 
             var json = Encoding.UTF8.GetString(await game.DownloadAsLauncher(url, language, "application/json, text/plain, */*").ConfigureAwait(false));
 
-            return JsonConvert.DeserializeObject<Headlines>(json, Converter.SETTINGS);
+            var news = JsonConvert.DeserializeObject<Headlines>(json, Converter.SETTINGS);
+            foreach (var item in news.News)
+            {
+                if (string.IsNullOrEmpty(item.Url) && !string.IsNullOrEmpty(item.Id))
+                {
+                    item.Url = $"https://{language.GetLangCodeLodestone()}.finalfantasyxiv.com/lodestone/news/detail/{item.Id}";
+                }
+            }
+            foreach (var item in news.Topics)
+            {
+                if (string.IsNullOrEmpty(item.Url) && !string.IsNullOrEmpty(item.Id))
+                {
+                    item.Url = $"https://{language.GetLangCodeLodestone()}.finalfantasyxiv.com/lodestone/topics/detail/{item.Id}";
+                }
+            }
+            return news;
         }
 
         public static async Task<IReadOnlyList<Banner>> GetBanners(Launcher game, ClientLanguage language, bool forceNa = false)


### PR DESCRIPTION
The ID provided in all entries is the same as the ID of the lodestone post entry so we can use that as to create a fallback URL. News items never have a URL assigned as they are shown in the official launcher without opening a browser