### PR TITLE
Add support for Encrypted DNS

### DIFF
--- a/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/AriaHttpPatchAcquisition.cs
+++ b/src/XIVLauncher.Common/Game/Patch/Acquisition/Aria/AriaHttpPatchAcquisition.cs
@@ -55,7 +55,7 @@ namespace XIVLauncher.Common.Game.Patch.Acquisition.Aria
                 var ariaHost = $"http://localhost:{ariaPort}/jsonrpc";
 
                 var ariaArgs =
-                    $"--enable-rpc --rpc-secret={secret} --rpc-listen-port={ariaPort} --log=\"{logFile.FullName}\" --log-level=notice --max-connection-per-server=8 --auto-file-renaming=false --allow-overwrite=true";
+                    $"--enable-rpc --rpc-secret={secret} --rpc-listen-port={ariaPort} --log=\"{logFile.FullName}\" --log-level=notice --max-connection-per-server=8 --auto-file-renaming=false --allow-overwrite=true --async-dns=false";
 
                 Log.Verbose($"[ARIA] Aria process not there, creating from {ariaPath} {ariaArgs}...");
 


### PR DESCRIPTION
If you block unencrypted DNS port 53, you can't download any game patches through XIVLauncher.
Fixed by disabling Aria's built-in asynchronous DNS resolver and instead use the system's default DNS resolver.

Downloads doesn't start with async-dns enabled: 
![image](https://github.com/user-attachments/assets/e4d2c3f8-aeb5-499a-bb76-2cd0cc7eee09)

