### PR TITLE
Make Cancel Buttons Red

### DIFF
--- a/src/XIVLauncher/Windows/BetaKeyDialog.xaml
+++ b/src/XIVLauncher/Windows/BetaKeyDialog.xaml
@@ -18,8 +18,8 @@
         <TextBlock Text="Enter your beta key to unlock hidden branches." Grid.Row="0" Margin="0,0,0,10" FontSize="14"/>
         <TextBox x:Name="BetaKeyTextBox" Grid.Row="1" Height="32" materialDesign:HintAssist.Hint="Beta Key" Margin="0,0,0,10" />
         <StackPanel Grid.Row="2" Orientation="Horizontal" HorizontalAlignment="Right">
-            <Button Content="Cancel" Width="80" Margin="0,0,10,0" Click="CancelButton_Click" />
-            <Button Content="Unlock" Width="80" Click="UnlockButton_Click" />
+            <Button Content="Unlock" Width="80" Margin="0,0,10,0" Click="UnlockButton_Click" />
+            <Button Content="Cancel" Width="80" Click="CancelButton_Click" Style="{StaticResource MaterialDesignRaisedCancelButton}" />
         </StackPanel>
     </Grid>
 </Window>

--- a/src/XIVLauncher/Windows/CustomMessageBox.xaml.cs
+++ b/src/XIVLauncher/Windows/CustomMessageBox.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -78,6 +78,7 @@ namespace XIVLauncher.Windows
                 case MessageBoxButton.OKCancel:
                     Button1.Content = builder.OkButtonText ?? ViewModel.OkLoc;
                     Button2.Content = builder.CancelButtonText ?? ViewModel.CancelWithShortcutLoc;
+                    Button2.Style = (Style)this.FindResource("MaterialDesignRaisedCancelButton");
                     Button3.Visibility = Visibility.Collapsed;
                     (builder.DefaultResult switch
                     {
@@ -89,7 +90,9 @@ namespace XIVLauncher.Windows
                 case MessageBoxButton.YesNoCancel:
                     Button1.Content = builder.YesButtonText ?? ViewModel.YesWithShortcutLoc;
                     Button2.Content = builder.NoButtonText ?? ViewModel.NoWithShortcutLoc;
+                    Button2.Style = (Style)this.FindResource("MaterialDesignRaisedCancelButton");
                     Button3.Content = builder.CancelButtonText ?? ViewModel.CancelWithShortcutLoc;
+                    Button3.Style = (Style)this.FindResource("MaterialDesignRaisedCancelButton");
                     (builder.DefaultResult switch
                     {
                         MessageBoxResult.Yes => Button1,
@@ -101,6 +104,7 @@ namespace XIVLauncher.Windows
                 case MessageBoxButton.YesNo:
                     Button1.Content = builder.YesButtonText ?? ViewModel.YesWithShortcutLoc;
                     Button2.Content = builder.NoButtonText ?? ViewModel.NoWithShortcutLoc;
+                    Button2.Style = (Style)this.FindResource("MaterialDesignRaisedCancelButton");
                     Button3.Visibility = Visibility.Collapsed;
                     (builder.DefaultResult switch
                     {

--- a/src/XIVLauncher/Windows/DalamudBranchSwitcherWindow.xaml
+++ b/src/XIVLauncher/Windows/DalamudBranchSwitcherWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window
+<Window
     x:Class="XIVLauncher.Windows.DalamudBranchSwitcherWindow"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
@@ -56,10 +56,8 @@
             </Grid.ColumnDefinitions>
             <Button Content="Have a beta key?" Height="32" Width="160" Grid.Column="0" HorizontalAlignment="Left" Click="BetaKeyButton_Click" />
             <StackPanel Orientation="Horizontal" Grid.Column="1" HorizontalAlignment="Right">
-                <Border BorderBrush="{DynamicResource MaterialDesign.Brush.Primary}" BorderThickness="2" CornerRadius="4" Margin="0,0,10,0" HorizontalAlignment="Left">
-                    <Button Content="Never mind" Height="32" Width="120" Style="{DynamicResource MaterialDesignFlatButton}" Foreground="Gray" Click="NeverMindButton_Click" />
-                </Border>
-                <Button Content="Switch Branch" Width="150" Height="32" Click="SwitchBranchButton_Click" />
+                <Button Content="Switch Branch" Width="150" Height="32" Margin="0,0,10,0" Click="SwitchBranchButton_Click" />
+                <Button Content="Never mind" Style="{StaticResource MaterialDesignRaisedCancelButton}" Width="150" Height="32" Click="NeverMindButton_Click" />
             </StackPanel>
         </Grid>
     </Grid>

--- a/src/XIVLauncher/Windows/GameRepairProgressWindow.xaml
+++ b/src/XIVLauncher/Windows/GameRepairProgressWindow.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="XIVLauncher.Windows.GameRepairProgressWindow"
+<Window x:Class="XIVLauncher.Windows.GameRepairProgressWindow"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -22,7 +22,7 @@
                 <TextBlock Foreground="{DynamicResource MaterialDesignBody}" HorizontalAlignment="Center" x:Name="StatusTextBlock" Margin="0,2,0,0">Status</TextBlock>
                 <TextBlock Foreground="{DynamicResource MaterialDesignBody}" HorizontalAlignment="Center" x:Name="SpeedTextBlock" Margin="0,2,0,0">Speed</TextBlock>
                 <TextBlock Foreground="{DynamicResource MaterialDesignBody}" HorizontalAlignment="Center" x:Name="EstimatedTimeTextBlock" Margin="0,2,0,0">Estimated duration</TextBlock>
-                <Button Content="{Binding CancelWithShortcutLoc}" Command="{Binding Path=CancelCommand}" x:Name="CancelButton" Margin="0,10,0,0" Width="84" />
+                <Button Style="{StaticResource MaterialDesignRaisedCancelButton}" Content="{Binding CancelWithShortcutLoc}" Command="{Binding Path=CancelCommand}" x:Name="CancelButton" Margin="0,10,0,0" Width="84" />
             </StackPanel>
         </materialDesign:Card>
     </Grid>

--- a/src/XIVLauncher/Windows/OtpInputDialog.xaml
+++ b/src/XIVLauncher/Windows/OtpInputDialog.xaml
@@ -1,4 +1,4 @@
-﻿<Window x:Class="XIVLauncher.Windows.OtpInputDialog"
+<Window x:Class="XIVLauncher.Windows.OtpInputDialog"
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -70,6 +70,7 @@
                         Width="100"
                         Click="OkButton_OnClick" />
                     <Button
+                        Style="{StaticResource MaterialDesignRaisedCancelButton}"
                         Content="{Binding CancelWithShortcutLoc}"
                         Margin="7,0,0,0"
                         Width="100"

--- a/src/XIVLauncher/Xaml/Components/MaterialDesignOverrides.xaml
+++ b/src/XIVLauncher/Xaml/Components/MaterialDesignOverrides.xaml
@@ -1,9 +1,12 @@
-﻿<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"                                     
                     xmlns:materialDesign="clr-namespace:MaterialDesignThemes.Wpf;assembly=MaterialDesignThemes.Wpf">
 
-    <Style x:Key="MaterialDesignToggleButtonWithIcon" BasedOn="{StaticResource MaterialDesignFloatingActionButton}" TargetType="{x:Type ToggleButton}">
-        
+    <Style x:Key="MaterialDesignToggleButtonWithIcon" BasedOn="{StaticResource MaterialDesignFloatingActionButton}" TargetType="{x:Type ToggleButton}" />
+
+    <Style x:Key="MaterialDesignRaisedCancelButton" BasedOn="{StaticResource MaterialDesignRaisedButton}" TargetType="{x:Type Button}">
+        <Setter Property="Background" Value="#FFAB3838" />
+        <Setter Property="BorderBrush" Value="#FFA71919" />
     </Style>
 
 </ResourceDictionary>


### PR DESCRIPTION
Added a new style `MaterialDesignRaisedCancelButton` to `src\XIVLauncher\Xaml\Components\MaterialDesignOverrides.xaml` that gives cancel buttons a red background and border.

### OTP Dialog

<img width="260" height="166" alt="OTP Dialog" src="https://github.com/user-attachments/assets/ab2fe792-38b8-428c-b629-1e18c44ebc6b" />

### Branch Switcher

Swapped "Never mind" and "Switch Branch" buttons position, so the "cancel" button is on the right side, as in the OTP Dialog.

<img width="906" height="393" alt="Branch Switcher" src="https://github.com/user-attachments/assets/80464b63-9061-4234-96b5-16540f1e27dc" />

### Beta Key Window

Swapped "Cancel" and "Unlock" buttons position, so the Cancel button is on the right side, as in the OTP Dialog.

<img width="373" height="209" alt="Beta Key" src="https://github.com/user-attachments/assets/1fea8c67-a496-4e1b-b68a-3af9fe8dfaf3" />

### CustomMessageBox Window

<img width="602" height="192" alt="CustomMessageBox" src="https://github.com/user-attachments/assets/4d32e662-f72f-459e-9389-48c719bc17a8" />

### Game Repair Progress

<img width="255" height="190" alt="Game Repair Progress" src="https://github.com/user-attachments/assets/89615a99-0990-41c8-91c3-dfd7482f4bea" />

