### PR TITLE
Fix XIVLauncher.PatchInstaller not working correctly on publish

### DIFF
--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -26,32 +26,7 @@ jobs:
       - name: Publish XIVLauncher.Patcher # This is to fix the missing .deps.json
         run: |
           cd src/XIVLauncher.PatchInstaller
-          dotnet publish --self-contained -r win-x64 -o publish
-      - name: Combine Publishes # This is to fix the missing .deps.json but skips same files
-        run: |
-          $SourceFolder = "./src/XIVLauncher.PatchInstaller/publish"
-          $DestinationFolder = "./src/XIVLauncher/publish"
-          robocopy $SourceFolder $DestinationFolder /S /E /XO /IT
-          $lastExitCode = $LASTEXITCODE
-          if ($lastExitCode -eq 0) {
-            Write-Host "Robocopy completed successfully with no changes."
-          } elseif ($lastExitCode -eq 1) {
-            Write-Host "Robocopy completed successfully; All files were copied successfully."
-          } elseif ($lastExitCode -eq 2) {
-            Write-Host "Robocopy completed successfully; There are some additional files in the destination directory that aren't present in the source directory. No files were copied."
-          } elseif ($lastExitCode -eq 3) {
-            Write-Host "Robocopy completed successfully; Some files were copied. Additional files were present. No failure was met."
-          } elseif ($lastExitCode -eq 5) {
-            Write-Host "Robocopy completed successfully; Some files were copied. Some files were mismatched. No failure was met."
-          } elseif ($lastExitCode -eq 6) {
-            Write-Host "Robocopy completed successfully; Additional files and mismatched files exist. No files were copied and no failures were met. Which means that the files already exist in the destination directory."
-          } elseif ($lastExitCode -eq 7) {
-            Write-Host "Robocopy completed successfully; Files were copied, a file mismatch was present, and additional files were present."
-          } else {
-            Write-Error "Robocopy encountered errors. Exit code: $lastExitCode"
-            exit 1
-          }
-          exit 0
+          dotnet publish --self-contained -r win-x64 -o ../XIVLauncher/publish/patcher
       - name: Generate Hashes File
         run: ./scripts/CreateHashList.ps1 ./src/XIVLauncher/publish
       - name: Attest Artifacts
@@ -79,11 +54,9 @@ jobs:
           Invoke-WebRequest -Uri $delta_file.browser_download_url -OutFile ".\Releases\$($delta_file.name)"
           $full_file = $current.assets | Where-Object -Property name -Value "*full.nupkg" -Like
           Invoke-WebRequest -Uri $full_file.browser_download_url -OutFile ".\Releases\$($full_file.name)"
-          vpk pack -u XIVLauncher -v $refver -p .\publish\ -e XIVLauncher.exe -i .\Resources\dalamud_icon.ico
-          Start-Sleep -s 60
+          vpk pack -u XIVLauncher -v $refver -p .\publish\ -e XIVLauncher.exe -i .\Resources\dalamud_icon.ico --noProtable
           rm ".\Releases\$($delta_file.name)"
           rm ".\Releases\$($full_file.name)"
-          rm ".\Releases\XIVLauncher-win-Portable.zip"
       - name: Attest Setup
         if: ${{ github.repository_owner == 'goatcorp' && github.event_name == 'push' }}
         uses: actions/attest-build-provenance@v1

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -23,6 +23,15 @@ jobs:
         run: |
           cd src/XIVLauncher
           dotnet publish --self-contained -r win-x64 -o publish
+      - name: Publish XIVLauncher.Patcher # This is to fix the missing .deps.json
+        run: |
+          cd src/XIVLauncher.PatchInstaller
+          dotnet publish --self-contained -r win-x64 -o publish
+      - name: Combine Publishes # This is to fix the missing .deps.json but skips same files
+        run: |
+          $SourceFolder = "./src/XIVLauncher.PatchInstaller/publish"
+          $DestinationFolder = "./src/XIVLauncher/publish"
+          robocopy $SourceFolder $DestinationFolder /S /E /XO /IT
       - name: Generate Hashes File
         run: ./scripts/CreateHashList.ps1 ./src/XIVLauncher/publish
       - name: Attest Artifacts

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -23,7 +23,7 @@ jobs:
         run: |
           cd src/XIVLauncher
           dotnet publish --self-contained -r win-x64 -o publish
-      - name: Publish XIVLauncher.Patcher # This is to fix the missing .deps.json
+      - name: Publish XIVLauncher.Patcher
         run: |
           cd src/XIVLauncher.PatchInstaller
           dotnet publish --self-contained -r win-x64 -o ../XIVLauncher/publish/patcher
@@ -54,7 +54,8 @@ jobs:
           Invoke-WebRequest -Uri $delta_file.browser_download_url -OutFile ".\Releases\$($delta_file.name)"
           $full_file = $current.assets | Where-Object -Property name -Value "*full.nupkg" -Like
           Invoke-WebRequest -Uri $full_file.browser_download_url -OutFile ".\Releases\$($full_file.name)"
-          vpk pack -u XIVLauncher -v $refver -p .\publish\ -e XIVLauncher.exe -i .\Resources\dalamud_icon.ico --noProtable
+          vpk pack -u XIVLauncher -v $refver -p .\publish\ -e XIVLauncher.exe -i .\Resources\dalamud_icon.ico --noPortable
+          Start-Sleep -s 10
           rm ".\Releases\$($delta_file.name)"
           rm ".\Releases\$($full_file.name)"
       - name: Attest Setup
@@ -100,6 +101,10 @@ jobs:
         run: |
           cd src/XIVLauncher
           dotnet publish --self-contained -r win-x64 -o publish
+      - name: Publish XIVLauncher.Patcher
+        run: |
+          cd src/XIVLauncher.PatchInstaller
+          dotnet publish --self-contained -r win-x64 -o ../XIVLauncher/publish/patcher
       - name: Generate Hashes File
         run: ./scripts/CreateHashList.ps1 ./src/XIVLauncher/publish/
       - name: Attest Artifacts

--- a/.github/workflows/ci-workflow.yml
+++ b/.github/workflows/ci-workflow.yml
@@ -32,6 +32,26 @@ jobs:
           $SourceFolder = "./src/XIVLauncher.PatchInstaller/publish"
           $DestinationFolder = "./src/XIVLauncher/publish"
           robocopy $SourceFolder $DestinationFolder /S /E /XO /IT
+          $lastExitCode = $LASTEXITCODE
+          if ($lastExitCode -eq 0) {
+            Write-Host "Robocopy completed successfully with no changes."
+          } elseif ($lastExitCode -eq 1) {
+            Write-Host "Robocopy completed successfully; All files were copied successfully."
+          } elseif ($lastExitCode -eq 2) {
+            Write-Host "Robocopy completed successfully; There are some additional files in the destination directory that aren't present in the source directory. No files were copied."
+          } elseif ($lastExitCode -eq 3) {
+            Write-Host "Robocopy completed successfully; Some files were copied. Additional files were present. No failure was met."
+          } elseif ($lastExitCode -eq 5) {
+            Write-Host "Robocopy completed successfully; Some files were copied. Some files were mismatched. No failure was met."
+          } elseif ($lastExitCode -eq 6) {
+            Write-Host "Robocopy completed successfully; Additional files and mismatched files exist. No files were copied and no failures were met. Which means that the files already exist in the destination directory."
+          } elseif ($lastExitCode -eq 7) {
+            Write-Host "Robocopy completed successfully; Files were copied, a file mismatch was present, and additional files were present."
+          } else {
+            Write-Error "Robocopy encountered errors. Exit code: $lastExitCode"
+            exit 1
+          }
+          exit 0
       - name: Generate Hashes File
         run: ./scripts/CreateHashList.ps1 ./src/XIVLauncher/publish
       - name: Attest Artifacts

--- a/src/XIVLauncher.Common.Windows/XIVLauncher.Common.Windows.csproj
+++ b/src/XIVLauncher.Common.Windows/XIVLauncher.Common.Windows.csproj
@@ -4,7 +4,7 @@
         <AssemblyTitle>XIVLauncher.Common.Windows</AssemblyTitle>
         <Description>Shared XIVLauncher platform-specific implementations for Windows.</Description>
         <VersionPrefix>1.0.0</VersionPrefix>
-        <Nullable>disable</Nullable>
+        <Nullable>enable</Nullable>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>
 

--- a/src/XIVLauncher.Common/Game/Patch/PatchInstaller.cs
+++ b/src/XIVLauncher.Common/Game/Patch/PatchInstaller.cs
@@ -42,7 +42,7 @@ namespace XIVLauncher.Common.Game.Patch
                 this.rpc = new SharedMemoryRpc(rpcName);
                 this.rpc.MessageReceived += RemoteCallHandler;
 
-                var path = Path.Combine(AppContext.BaseDirectory, "XIVLauncher.PatchInstaller.exe");
+                var path = Path.Combine(AppContext.BaseDirectory, "patcher", "XIVLauncher.PatchInstaller.exe");
 
                 var startInfo = new ProcessStartInfo(path);
                 startInfo.UseShellExecute = true;

--- a/src/XIVLauncher.Common/Game/Patch/PatchVerifier.cs
+++ b/src/XIVLauncher.Common/Game/Patch/PatchVerifier.cs
@@ -299,7 +299,7 @@ namespace XIVLauncher.Common.Game.Patch
 
                 if (_external)
                 {
-                    indexedZiPatchIndexInstaller = new IndexedZiPatchIndexRemoteInstaller(Path.Combine(assemblyLocation!, "XIVLauncher.PatchInstaller.exe"),
+                    indexedZiPatchIndexInstaller = new IndexedZiPatchIndexRemoteInstaller(Path.Combine(assemblyLocation!, "patcher", "XIVLauncher.PatchInstaller.exe"),
                                                                                           needElevation);
                 }
                 else

--- a/src/XIVLauncher.Common/XIVLauncher.Common.csproj
+++ b/src/XIVLauncher.Common/XIVLauncher.Common.csproj
@@ -4,7 +4,7 @@
         <AssemblyTitle>XIVLauncher.Common</AssemblyTitle>
         <Description>Common components for XIVLauncher.</Description>
         <VersionPrefix>1.0.0</VersionPrefix>
-        <Nullable>disable</Nullable>
+        <Nullable>enable</Nullable>
 
         <ProduceReferenceAssembly>true</ProduceReferenceAssembly>
 

--- a/src/XIVLauncher/XIVLauncher.csproj
+++ b/src/XIVLauncher/XIVLauncher.csproj
@@ -80,7 +80,6 @@
   <ItemGroup>
     <ProjectReference Include="..\XIVLauncher.Common.Windows\XIVLauncher.Common.Windows.csproj" />
     <ProjectReference Include="..\XIVLauncher.Common\XIVLauncher.Common.csproj" />
-    <ProjectReference Include="..\XIVLauncher.PatchInstaller\XIVLauncher.PatchInstaller.csproj" />
   </ItemGroup>
 
   <!-- Git -->


### PR DESCRIPTION
Things changed with this PR:
- `XIVLauncher.PatchInstaller` is built into a subdirectory of `patcher` under `XIVLauncher` publish folder
  - The places the exe was triggered also has been updated to reflect this new location.
- `velopack` has a no portable mode which wasn't enabled in CI
- `XIVLauncher.Common` didn't have nullable set correctly but now is causing less log spam in CI
