### PR TITLE
fix: Use OSDescription for clearer OS info

### DIFF
--- a/src/XIVLauncher/Windows/CustomMessageBox.xaml.cs
+++ b/src/XIVLauncher/Windows/CustomMessageBox.xaml.cs
@@ -3,6 +3,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Media;
+using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading;
 using System.Windows;
@@ -342,7 +343,7 @@ namespace XIVLauncher.Windows
                 this.WithAppendDescription("\n\nVersion: " + AppUtil.GetAssemblyVersion())
                     .WithAppendDescription("\nGit Hash: " + AppUtil.GetGitHash())
                     .WithAppendDescription("\nContext: " + context)
-                    .WithAppendDescription("\nOS: " + Environment.OSVersion)
+                    .WithAppendDescription("\nOS: " + RuntimeInformation.OSDescription)
                     .WithAppendDescription("\n64bit? " + Environment.Is64BitProcess);
                 if (App.Settings != null)
                 {


### PR DESCRIPTION
This PR updates OS information to use `RuntimeInformation.OSDescription` instead of `Environment.OSVersion`.

**Reasoning**

`Environment.OSVersion` reports kernel version that is not useful for identifying a System Version.

[RuntimeInformation.OSDescription](https://learn.microsoft.com/en-us/dotnet/api/system.runtime.interopservices.runtimeinformation.osdescription?view=net-9.0) provides a more accurate and descriptive string that includes the OS build number and works consistently across platforms.

I'm not replacing other instances because it's not recommended to parse this string for information, the output format can vary between platforms:

- Windows: `Microsoft Windows 10.0.19045`
- Linux: `Linux 5.15.0-106-generic #107-Ubuntu SMP`
- macOS: `Darwin 22.6.0 Darwin Kernel Version 22.6.0`