### PR TITLE
Fix Remote Patcher failure on Finish

### DIFF
--- a/src/XIVLauncher.Common/Game/Patch/PatchInstaller.cs
+++ b/src/XIVLauncher.Common/Game/Patch/PatchInstaller.cs
@@ -164,7 +164,7 @@ namespace XIVLauncher.Common.Game.Patch
             this.rpc.SendMessage(new PatcherIpcEnvelope
             {
                 OpCode = PatcherIpcOpCode.Finish,
-                Data = gameDirectory
+                Data = gameDirectory.ToString()
             });
 
             var cts = new CancellationTokenSource(5000);


### PR DESCRIPTION
This corrects the casting for the Remote Patch Installer on Finish, which triggers failures in Core.

See: https://github.com/goatcorp/XIVLauncher.Core/pull/287#issuecomment-3669901846 for context

Tested on Linux via Flatpak