### PR TITLE
fix: Don't root paths for free space calculations

### DIFF
--- a/src/XIVLauncher.Common/Util/PlatformHelpers.cs
+++ b/src/XIVLauncher.Common/Util/PlatformHelpers.cs
@@ -190,7 +190,7 @@ public static class PlatformHelpers
 
         ulong dummy = 0;
 
-        if (!GetDiskFreeSpaceEx(info.Root.FullName, out ulong freeSpace, out dummy, out dummy))
+        if (!GetDiskFreeSpaceEx(info.FullName, out ulong freeSpace, out dummy, out dummy))
         {
             throw new System.ComponentModel.Win32Exception(System.Runtime.InteropServices.Marshal.GetLastWin32Error());
         }


### PR DESCRIPTION
`GetDiskFreeSpaceEx` allows passing in a full directory name, and will automatically resolve any reparse or volume mount points accordingly. The existing `.Root` would have always returned the base drive, thereby potentially showing invalid out of space warnings.

Linux code already passes the full path into `DriveInfo`, which will properly resolve the mount point already. For some reason, Windows' `DriveInfo` [will not properly handle mount points](https://learn.microsoft.com/en-us/dotnet/api/system.io.driveinfo.-ctor?view=net-10.0), so we still need the P/Invoke and native call.

Fixes #1820. 

