### PR TITLE
Increase 1password automatic login robustness by adding retries + bugfixes

### DIFF
--- a/misc/1password-cli-otp/automatic-login.ps1
+++ b/misc/1password-cli-otp/automatic-login.ps1
@@ -1,8 +1,21 @@
+# Wraps Sending the OTP to FFXIV Launcher so we can just see if it succeeds
+function SendOTP {
+  param ([string] $OTP)
+  try {
+    Invoke-WebRequest -URI "http://127.0.0.1:4646/ffxivlauncher/$OTP" 
+    return $true
+  }
+  catch {
+    return $false
+  }
+}
+
 # You shouldn't need to modify this unless you have a custom launcher install
-$LauncherPath = "$env:LOCALAPPDATA\XIVLauncher\XIVLauncher.exe"
+$LauncherPath = "$env:LOCALAPPDATA\XIVLauncher\current\XIVLauncher.exe"
 # The name of the login item containing your FFXIV OTP
 $VaultItemName = "Square Enix"
-
+$ATTEMPTS = 5
+$BACKOFF = 2
 $OTP = op item get $VaultItemName --otp
 
 if ($OTP.length -eq 6) {
@@ -10,11 +23,15 @@ if ($OTP.length -eq 6) {
   # Check "Log in automatically" on the main launcher screen
   Start-Process powershell -ArgumentList $LauncherPath
   [System.Net.ServicePointManager]::ServerCertificateValidationCallback = { $true }
-  Start-Sleep -Seconds 2
-  try {
-    Invoke-WebRequest -URI "http://127.0.0.1:4646/ffxivlauncher/$OTP"
-  } catch { }
-} else {
+  for ($i = 0; $i -lt $ATTEMPTS; $i++) {
+    Start-Sleep -Seconds $BACKOFF
+    $success = SendOTP $OTP
+    if ($success) {
+      break
+    }
+  }
+}
+else {
   Write-Error "Failed to authenticate or malformed OTP"
   Read-Host -Prompt "Press Enter to exit"
 }


### PR DESCRIPTION
I was using the 1password automatic login script for my account that has OTP enabled, and noticed that it would randomly fail. This seems to be caused by a race condition between the software launching and the sleep in the script. To mitigate this, I made it so that the script tries to send the OTP to XIVlauncher with backed-off retries (5 tries, spaced out by 2 seconds each) until it succeeds. 
There should be no broader implications to the overall project, and no noticeable change in behavior for existing users of the script.  

I also fixed the install directory for XIV launcher so that it uses the most recent path.

