### PR TITLE
Use XDG_DATA_HOME/dev.goats.xlcore for storage on Linux

### DIFF
--- a/src/XIVLauncher.Common/Storage.cs
+++ b/src/XIVLauncher.Common/Storage.cs
@@ -23,7 +23,7 @@ public class Storage
         else
         {
             // Keeping the old path on MacOS for now.
-            this.Root = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $".{appName}"));
+            this.Root = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".{appName}"));
         }
 
         if (!string.IsNullOrEmpty(overridePath))

--- a/src/XIVLauncher.Common/Storage.cs
+++ b/src/XIVLauncher.Common/Storage.cs
@@ -14,14 +14,9 @@ public class Storage
         {
             this.Root = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), appName));
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)  || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
-        {
-            // Use XDG_DATA_HOME on Linux.
-            this.Root = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName));
-        }
         else
         {
-            this.Root = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".{appName}"));
+            this.Root = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName));
         }
 
         if (!string.IsNullOrEmpty(overridePath))

--- a/src/XIVLauncher.Common/Storage.cs
+++ b/src/XIVLauncher.Common/Storage.cs
@@ -15,14 +15,13 @@ public class Storage
         {
             this.Root = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), appName));
         }
-        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)  || RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
         {
             // Use XDG_DATA_HOME on Linux.
-            this.Root = this.getXDGStoragePath(appName);
+            this.Root = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), appName));
         }
         else
         {
-            // Keeping the old path on MacOS for now.
             this.Root = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".{appName}"));
         }
 
@@ -33,108 +32,6 @@ public class Storage
 
         if (!this.Root.Exists)
             this.Root.Create();
-    }
-
-    private DirectoryInfo getXDGStoragePath(string appName)
-    {
-        var xdgStorage = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $"dev.goats.{appName}"));
-        var oldStorage = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".{appName}"));
-
-        if (xdgStorage.Exists)
-            return xdgStorage;  // Use the XDG path if it already exists.
-
-        if (oldStorage.Exists)
-        {
-            if (unixStorageIsMovable(xdgStorage.FullName, oldStorage.FullName))
-            {
-                oldStorage.MoveTo(xdgStorage.FullName); // Move ~/.{appName} to XDG_DATA_HOME/dev.goats.{appName}, since it's confirmed to be on the same drive.
-                return xdgStorage;
-            }
-            return oldStorage; // Fallback to ~/.{appName} if we can't move it to XDG_DATA_HOME for some reason.
-        }
-
-        return xdgStorage; // Use the XDG path for new installations.
-    }
-
-    private bool unixStorageIsMovable(string unixStorage, string oldStorage)
-    {
-        // Future implementation note: Dotnet 11 preview currently allows for the testing hardlinks, which would allow us to try creating a hardlink
-        // from a test file in the old location to a test file in the new location. If it succeeded, we'd know they were on the same drive.
-        
-        // We need to get the real absolute paths of both directories, resolving any symlinks, to accurately determine if they are on the same drive.
-        // This is for SteamOS, Bazzite, and other similar distros, which mount things under /var and then put symlinks under /.
-        var unixRealPath = unixGetRealPath(unixStorage);
-        var oldRealPath = unixGetRealPath(oldStorage);
-
-        if (unixRealPath == null || oldRealPath == null)
-        {
-            return false; // If we can't resolve the real path of either directory, we assume they are not movable.
-        }
-
-        try
-        {
-            var drives = DriveInfo.GetDrives();
-            int unixHitCounter = 0;
-            int oldHitCounter = 0;
-            
-            // Unix dotnet enumerates drives for each mounted path, including various virtual filesystems like /proc and /sys.
-            // To determine if two folders are on the same drive, we'll match them to mounted partitions and count the hits.
-            // This is to get around edge cases where someone did something weird like mount a partition to ~/.xlcore or ~/.local/share.
-            // If they match the same number of partitions, and at least one, we can be reasonably sure they're on the same partition, and safe to move.
-            foreach (var drive in drives)
-            {
-                if (unixRealPath.StartsWith(drive.RootDirectory.FullName))
-                {
-                    unixHitCounter++;
-                }
-                if (oldRealPath.StartsWith(drive.RootDirectory.FullName))
-                {
-                    oldHitCounter++;
-                }
-            }
-            if (unixHitCounter == oldHitCounter && unixHitCounter > 0)
-            {
-                return true;
-            }
-            return false; // The files are on different drives, so they are not movable.
-        }
-        catch
-        {
-            return false; // If any exception occurs, we assume the move failed and return false.
-        }
-    }
-
-    private static string? unixGetRealPath(string path)
-    {
-        // There's no good way to resolve the real path of a file in .NET on Linux and MacOS,
-        // since .NET doesn't have a built-in way to do it. Path.GetFullPath does not work.
-        // The best we can do is to call the "realpath" command-line utility, which is available on both Linux and MacOS.
-        var startInfo = new ProcessStartInfo
-        {
-            FileName = "realpath",
-            Arguments = path,
-            RedirectStandardOutput = true,
-            UseShellExecute = false,
-            CreateNoWindow = true
-        };
-        using (var process = new Process { StartInfo = startInfo })
-        {
-            try
-            {
-                process.Start();
-                string realPath = process.StandardOutput.ReadToEnd().Trim();
-                process.WaitForExit();
-                if (process.ExitCode != 0)
-                {
-                    return null;
-                }
-                return realPath;
-            }
-            catch
-            {
-                return null; // If any exception occurs, we assume we can't resolve the path and return null.
-            }
-        }
     }
 
     public FileInfo GetFile(string fileName)

--- a/src/XIVLauncher.Common/Storage.cs
+++ b/src/XIVLauncher.Common/Storage.cs
@@ -1,7 +1,6 @@
 using System;
 using System.IO;
 using System.Runtime.InteropServices;
-using System.Diagnostics;
 
 namespace XIVLauncher.Common;
 

--- a/src/XIVLauncher.Common/Storage.cs
+++ b/src/XIVLauncher.Common/Storage.cs
@@ -1,5 +1,7 @@
 using System;
 using System.IO;
+using System.Runtime.InteropServices;
+using System.Diagnostics;
 
 namespace XIVLauncher.Common;
 
@@ -9,13 +11,19 @@ public class Storage
 
     public Storage(string appName, string? overridePath = null)
     {
-        if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
         {
             this.Root = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), appName));
         }
+        else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
+        {
+            // Use XDG_DATA_HOME on Linux.
+            this.Root = this.getXDGStoragePath(appName);
+        }
         else
         {
-            this.Root = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".{appName}"));
+            // Keeping the old path on MacOS for now.
+            this.Root = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $".{appName}"));
         }
 
         if (!string.IsNullOrEmpty(overridePath))
@@ -25,6 +33,108 @@ public class Storage
 
         if (!this.Root.Exists)
             this.Root.Create();
+    }
+
+    private DirectoryInfo getXDGStoragePath(string appName)
+    {
+        var xdgStorage = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), $"dev.goats.{appName}"));
+        var oldStorage = new DirectoryInfo(Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), $".{appName}"));
+
+        if (xdgStorage.Exists)
+            return xdgStorage;  // Use the XDG path if it already exists.
+
+        if (oldStorage.Exists)
+        {
+            if (unixStorageIsMovable(xdgStorage.FullName, oldStorage.FullName))
+            {
+                oldStorage.MoveTo(xdgStorage.FullName); // Move ~/.{appName} to XDG_DATA_HOME/dev.goats.{appName}, since it's confirmed to be on the same drive.
+                return xdgStorage;
+            }
+            return oldStorage; // Fallback to ~/.{appName} if we can't move it to XDG_DATA_HOME for some reason.
+        }
+
+        return xdgStorage; // Use the XDG path for new installations.
+    }
+
+    private bool unixStorageIsMovable(string unixStorage, string oldStorage)
+    {
+        // Future implementation note: Dotnet 11 preview currently allows for the testing hardlinks, which would allow us to try creating a hardlink
+        // from a test file in the old location to a test file in the new location. If it succeeded, we'd know they were on the same drive.
+        
+        // We need to get the real absolute paths of both directories, resolving any symlinks, to accurately determine if they are on the same drive.
+        // This is for SteamOS, Bazzite, and other similar distros, which mount things under /var and then put symlinks under /.
+        var unixRealPath = unixGetRealPath(unixStorage);
+        var oldRealPath = unixGetRealPath(oldStorage);
+
+        if (unixRealPath == null || oldRealPath == null)
+        {
+            return false; // If we can't resolve the real path of either directory, we assume they are not movable.
+        }
+
+        try
+        {
+            var drives = DriveInfo.GetDrives();
+            int unixHitCounter = 0;
+            int oldHitCounter = 0;
+            
+            // Unix dotnet enumerates drives for each mounted path, including various virtual filesystems like /proc and /sys.
+            // To determine if two folders are on the same drive, we'll match them to mounted partitions and count the hits.
+            // This is to get around edge cases where someone did something weird like mount a partition to ~/.xlcore or ~/.local/share.
+            // If they match the same number of partitions, and at least one, we can be reasonably sure they're on the same partition, and safe to move.
+            foreach (var drive in drives)
+            {
+                if (unixRealPath.StartsWith(drive.RootDirectory.FullName))
+                {
+                    unixHitCounter++;
+                }
+                if (oldRealPath.StartsWith(drive.RootDirectory.FullName))
+                {
+                    oldHitCounter++;
+                }
+            }
+            if (unixHitCounter == oldHitCounter && unixHitCounter > 0)
+            {
+                return true;
+            }
+            return false; // The files are on different drives, so they are not movable.
+        }
+        catch
+        {
+            return false; // If any exception occurs, we assume the move failed and return false.
+        }
+    }
+
+    private static string? unixGetRealPath(string path)
+    {
+        // There's no good way to resolve the real path of a file in .NET on Linux and MacOS,
+        // since .NET doesn't have a built-in way to do it. Path.GetFullPath does not work.
+        // The best we can do is to call the "realpath" command-line utility, which is available on both Linux and MacOS.
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "realpath",
+            Arguments = path,
+            RedirectStandardOutput = true,
+            UseShellExecute = false,
+            CreateNoWindow = true
+        };
+        using (var process = new Process { StartInfo = startInfo })
+        {
+            try
+            {
+                process.Start();
+                string realPath = process.StandardOutput.ReadToEnd().Trim();
+                process.WaitForExit();
+                if (process.ExitCode != 0)
+                {
+                    return null;
+                }
+                return realPath;
+            }
+            catch
+            {
+                return null; // If any exception occurs, we assume we can't resolve the path and return null.
+            }
+        }
     }
 
     public FileInfo GetFile(string fileName)


### PR DESCRIPTION
Includes moving ~/.{appName} to the new location, or falling back to ~/.{appName} if it can't be moved due to different drives.

The test for moving is not completely exhaustive; there's probably some weird edge case with zfs or btrfs subvolumes, or very weirdly named directories that might cause a failure, but the basic test seems to work pretty well.

This does not change the behavior on Mac OS, because I'm not sure if XIVonMac still uses this repo, and I don't want to screw things up for them.