### PR TITLE
Add --autologin command line option

### DIFF
--- a/src/XIVLauncher/App.xaml.cs
+++ b/src/XIVLauncher/App.xaml.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Globalization;
 using System.IO;
 using System.Linq;
@@ -49,6 +49,9 @@ namespace XIVLauncher
 
             [CommandLine.Option("noautologin", Required = false, HelpText = "Disable autologin.")]
             public bool NoAutoLogin { get; set; }
+
+            [CommandLine.Option("autologin", Required = false, HelpText = "Enable autologin.")]
+            public bool AutoLogin { get; set; }
 
             [CommandLine.Option("gen-localizable", Required = false, HelpText = "Generate localizable files.")]
             public bool DoGenerateLocalizables { get; set; }
@@ -101,6 +104,7 @@ namespace XIVLauncher
         private MainWindow mainWindow;
 
         public static bool GlobalIsDisableAutologin { get; private set; }
+        public static bool GlobalIsAutologin { get; private set; }
         public static byte[] GlobalSteamTicket { get; private set; }
         public static DalamudUpdater DalamudUpdater { get; private set; }
 
@@ -343,6 +347,11 @@ namespace XIVLauncher
                 if (CommandLine.NoAutoLogin)
                 {
                     GlobalIsDisableAutologin = true;
+                }
+
+                if (CommandLine.AutoLogin)
+                {
+                    GlobalIsAutologin = true;
                 }
 
                 if (!string.IsNullOrEmpty(CommandLine.DoGenerateIntegrity))

--- a/src/XIVLauncher/Windows/MainWindow.xaml.cs
+++ b/src/XIVLauncher/Windows/MainWindow.xaml.cs
@@ -289,7 +289,7 @@ namespace XIVLauncher.Windows
                 App.Settings.AutologinEnabled = false;
             }
 
-            if (App.Settings.AutologinEnabled && savedAccount != null && !Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
+            if ((App.Settings.AutologinEnabled || App.GlobalIsAutologin) && !App.GlobalIsDisableAutologin && savedAccount != null && !Keyboard.Modifiers.HasFlag(ModifierKeys.Shift))
             {
                 Log.Information("Engaging Autologin...");
                 Model.TryLogin(savedAccount.UserName, savedAccount.Password,


### PR DESCRIPTION
Add an --autologin command-line argument to allow automatic login without changing the persistent setting.

I think the best solution would be to consolidate this into a single argument with a value, such as --autologin=True/False, but that would be a breaking change.